### PR TITLE
Replace musl download+compile with new musl-aarch64 package

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,23 +94,6 @@ set -e
 # 2024-01-01
 export SOURCE_DATE_EPOCH=1704067200
 
-wget https://www.musl-libc.org/releases/musl-1.2.5.tar.gz
-echo 'a9a118bbe84d8764da0ea0d28b3ab3fae8477fc7e4085d90102b8596fc7c75e4  musl-1.2.5.tar.gz' | sha256sum -c -
-tar xf musl-1.2.5.tar.gz
-
-# Arch Linux currently doesn't have cross-compiled musl libc, so we build our own
-pushd musl-1.2.5/
-CROSS_COMPILE="aarch64-linux-gnu-" \
-./configure --prefix=/usr/aarch64-linux-musl/lib/musl \
-  --exec-prefix=/usr/aarch64-linux-musl \
-  --enable-wrapper=all \
-  --target="aarch64-linux-musl" \
-  CFLAGS="-ffat-lto-objects"
-make
-make DESTDIR="/" install
-mv -v /lib/ld-musl-aarch64.so* /usr/aarch64-linux-musl/lib/
-popd
-
 # configure the right linker for cross compile
 mkdir -vp ~/.cargo
 printf '[target.aarch64-unknown-linux-musl]\\nlinker = "/usr/aarch64-linux-musl/bin/musl-gcc"\\n' > ~/.cargo/config.toml
@@ -135,10 +118,9 @@ What this does (in order)
 - Configure a version suffix to ensure an official Debian package of that version would take precedence
 - Configure the expected .deb build outputs and their expected checksum
 - Configure a `SOURCE_DATE_EPOCH` for file timestamps used inside the .deb
-- Download and compile a specific musl libc version for aarch64 cross-compile
-- Configure the linker we just built for Rust cross-compiling
+- Configure the right linker so we can cross-compile Rust for aarch64
 - Select a specific Rust release so it's documented which one has been used
-- Download musl toolchains for aarch64 and x86_64
+- Download Rust musl toolchains for aarch64 and x86_64
 - Build a statically linked release binary and embed the resolved dependency tree into a linker section for documentation purpose
 - Use cargo-deb to bundle the binary into a .deb file
 

--- a/pkgs/acme-redirect/build.toml
+++ b/pkgs/acme-redirect/build.toml
@@ -21,23 +21,6 @@ set -e
 # 2024-01-01
 export SOURCE_DATE_EPOCH=1704067200
 
-wget https://www.musl-libc.org/releases/musl-1.2.5.tar.gz
-echo 'a9a118bbe84d8764da0ea0d28b3ab3fae8477fc7e4085d90102b8596fc7c75e4  musl-1.2.5.tar.gz' | sha256sum -c -
-tar xf musl-1.2.5.tar.gz
-
-# Arch Linux currently doesn't have cross-compiled musl libc, so we build our own
-pushd musl-1.2.5/
-CROSS_COMPILE="aarch64-linux-gnu-" \
-./configure --prefix=/usr/aarch64-linux-musl/lib/musl \
-  --exec-prefix=/usr/aarch64-linux-musl \
-  --enable-wrapper=all \
-  --target="aarch64-linux-musl" \
-  CFLAGS="-ffat-lto-objects"
-make
-make DESTDIR="/" install
-mv -v /lib/ld-musl-aarch64.so* /usr/aarch64-linux-musl/lib/
-popd
-
 # configure the right linker for cross compile
 mkdir -vp ~/.cargo
 printf '[target.aarch64-unknown-linux-musl]\\nlinker = "/usr/aarch64-linux-musl/bin/musl-gcc"\\n' > ~/.cargo/config.toml

--- a/pkgs/acme-redirect/repro-env.lock
+++ b/pkgs/acme-redirect/repro-env.lock
@@ -43,11 +43,11 @@ signature = "iHUEABYKAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCZbDRHwAKCRBtQr3RFuAGj1S
 
 [[package]]
 name = "archlinux-keyring"
-version = "20240609-1"
+version = "20240709-1"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/a/archlinux-keyring/archlinux-keyring-20240609-1-any.pkg.tar.zst"
-sha256 = "1498cbf8f9511a7c4f52b40b392bf8779e9543195f2a0a95a9dcda7b49dd0f9f"
-signature = "iHUEABYKAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCZmYV4QAKCRBtQr3RFuAGj5TKAQC4YJtPS54Mbb1HpkGBtt/rnHcZJwCTGkZ5oyPcWqen+QD+ICYfcLg4P1+sj+hMfPmDXQf4aKBLDrFkKKvSvCgy6wY="
+url = "https://archive.archlinux.org/packages/a/archlinux-keyring/archlinux-keyring-20240709-1-any.pkg.tar.zst"
+sha256 = "a6f573fc97fc21b55504a4d75d010257792847a5b87f19edff4ffb662f6f53a2"
+signature = "iHUEABYKAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCZo2s1wAKCRBtQr3RFuAGj9MSAQDCI730nuxWZ70VM9xGZZZDyLwb6LdAN+fbUdkNzaE3wAEAsNqHKFnUKRnBXwGOv3j8VrP+XaGD0P2QJAEocEeWiQM="
 
 [[package]]
 name = "attr"
@@ -258,6 +258,14 @@ sha256 = "7605cb1ab1830dbdd564591d33adeec78ce79c1733bd98f36ba3e81eb9748b78"
 signature = "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCZk3zsF8UgAAAAAAuAChpc3N1ZXItZnByQG5vdGF0aW9ucy5vcGVucGdwLmZpZnRoaG9yc2VtYW4ubmV0MDVDNzc3NUE5RThCOTc3NDA3RkUwOEU2OUQ0QzVBQTE1NDI2REEwQQAKCRCdTFqhVCbaCugeAQDgJyrXuoZnSZFU/gz5rGccNOuGSgOvfYX2YTY1drfb/AEA4pmZIr4MJC/1XQF5AmrhxTX491TtbJgxdstI+1KysAs="
 
 [[package]]
+name = "gdbm"
+version = "1.24-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/g/gdbm/gdbm-1.24-1-x86_64.pkg.tar.zst"
+sha256 = "2712f2747f887ff19ad4151143e506e80254a0a0db0e8b968adb6634da7800ab"
+signature = "iHUEABYKAB0WIQRizHP4hOUpV7L92IObeih9mi7GCAUCZoa2fgAKCRCbeih9mi7GCKXhAQDIaNqIfZ2hIa29L7FE1axM7Ui45KQxU/XOCC2cnzisvAD/aecNLEqMxSnE/FsOhZdi0dAHLAuOjVRSpF6IbtF1NgM="
+
+[[package]]
 name = "gettext"
 version = "0.22.5-1"
 system = "archlinux"
@@ -267,11 +275,11 @@ signature = "iQEzBAABCAAdFiEEW34/txt/EDKaHAOrdx32Yn7faB8FAmY7WIYACgkQdx32Yn7faB9
 
 [[package]]
 name = "glib2"
-version = "2.80.3-2"
+version = "2.80.4-1"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/g/glib2/glib2-2.80.3-2-x86_64.pkg.tar.zst"
-sha256 = "5097ae4a68ce205c4ffa370d5d9ba3e4ad9afb97d61e3d3f61d9b944813e7ad4"
-signature = "iHUEABYKAB0WIQSDvIiJNRtd67toQW64rAhgDxCM3wUCZmjHogAKCRC4rAhgDxCM30ONAQDMZoZSkJDOZDPD9PMLvhbK1VJxJp8VRgdxG1OILR9kfAD/evaIoFqw0LCQaTkKdSavJURgzmjh9g+LJ4FM7OnIzwA="
+url = "https://archive.archlinux.org/packages/g/glib2/glib2-2.80.4-1-x86_64.pkg.tar.zst"
+sha256 = "047121788777ae88726ee10525fba0ab05cc495cdb336a45bea6cdd0793c8d06"
+signature = "iHUEABYKAB0WIQSDvIiJNRtd67toQW64rAhgDxCM3wUCZoxhigAKCRC4rAhgDxCM37jmAQCMi355gHS4atKFg2Zr5R5hElvjlTp2vx7s2MniqS4usAD+KrBXRueBCElmnuplANh2d71qDwjAG7FFueZk8bp61wA="
 
 [[package]]
 name = "glibc"
@@ -394,6 +402,14 @@ sha256 = "9abd6fd54052b48b2bac6e709e25e7be876f68d84949ed4615a3fb8803f2a736"
 signature = "iHUEABYKAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCZegwsQAKCRBtQr3RFuAGj3QXAQDqrsXu36gY3rprKLSh3b3O0VYDQk7UHHSCAveZEHpvxQD/dR6SLukPahSQ8LABJmCFHk4w4d1PgBDRCczcaMYR2QE="
 
 [[package]]
+name = "krb5"
+version = "1.21.3-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/k/krb5/krb5-1.21.3-1-x86_64.pkg.tar.zst"
+sha256 = "7ce8f30ccef0650b964defb7a539c72d5e40fcd288f5f397c1b824d3f4431b2b"
+signature = "iQIzBAABCgAdFiEE4kC1fixGMLp2ji8m/BtUfI2BcsgFAmaJc6UACgkQ/BtUfI2BcsjO0w//R4djAXEL1QcOF/Jh4Ukqy+k+AhvnNSJN5JPhOkvJKc7DqCudBaFcuHdGno6KIAyg42q9PjeIBWxH2kcIVojmGZ+zPvscdX0mjwJAxZ+tBDfa54eOqtnUMGbPDL5QoGeZjfhdQ0hHOFDkpioz8c1hVjdTRvqkC6J5uUGH2SQmD9HfBUFv5O9g/QW+JJI4kXFYnewZewrDOFAccYFjcBjioY1L898+2freJ2JOIh5acf1mtQol/cZhOQevQ/SdZ+BsYZOLp3QFU+IE4Wg+3h2ayEa88A7i/U6ln03GkYNySY1UmqKwrALE9ixW8BSKXoVldtjyiLFH1PHsr0QLmn1IBEt0bis5L059JEdaCv8JKeEElQORUQNLXS6fBV/Oo4oc6mI0SiyOvMPchwkrgvSkh2UKz4AGtpan5EvwRDdaNdhZiCVEDWLIZ6sm0sXRIoJzrB4SsCux9eZnma6Yls47PjgR75ZFbNCr/CHHpZMHyL7mjb8fpZl12mXRcRAMo+3laZsJxUUOymtf3gb/SKQ5rDlYfHxtFaoRvUzKOscUT1d5PQ90KAuD0rbRmUynxBd4FqLAPs7xpcFJtboAsLd1Iax04gAxNtmQQ9F2SujJD+h/LoPwtqu2rU07e9+rcXtKqwYqTxH8TDGpEERsxkUcaLkvsz3sOxIEAUzubYnBn4I="
+
+[[package]]
 name = "libarchive"
 version = "3.7.4-1"
 system = "archlinux"
@@ -411,11 +427,11 @@ signature = "iHUEABYKAB0WIQRizHP4hOUpV7L92IObeih9mi7GCAUCZgqJbQAKCRCbeih9mi7GCNv
 
 [[package]]
 name = "libbpf"
-version = "1.4.2-1"
+version = "1.4.3-1"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/l/libbpf/libbpf-1.4.2-1-x86_64.pkg.tar.zst"
-sha256 = "70e86fd8bf8e6a0850eed15a580376049d988a28e987afa4c311abd2b1af611c"
-signature = "iQIzBAABCgAdFiEE4kC1fixGMLp2ji8m/BtUfI2BcsgFAmZSc7YACgkQ/BtUfI2Bcsg/HBAAu1v9RTktILD/N34CyIuLCDci6qPeEC3oXDIpZLBnXTwcIwo2Hhhn5n3Sz+k/Tbb6gRMIRhsnqwpxANRo38B9QMODyfeM4wKDNusV1cYUtE/9X3g00dHOYwDu//a/eLj7vHnUWTnFT3zebtRqFUtsFCKr1gogppkQzKCuYx7Nhrl/Z/1md7LEQZXxKWt9d4VSjex4noNMu+7ZujWKZFfYjyPyBzX2mDe96VEBT8BGnMzMjHT07Z7094BAHmVBrNmaJYxkNn34zhMAnG03Lxq93RHgnRJ3K7yzx+rRuEwsqg+7w/47nvgq6K0EaB04jQ6HbW/uIAn3sWIYgMZFIeBxeiCn5qQsNH0u7kSy3fivVuKADmVNG7UphHa3CVcSUi+9nSgt7Ug1RM3vsfX6c/+OiJnQoDHl/ITNZTsmMjc+H0jcJf+3zHyLnKObgEDOTehixOHWUnA8I0MgGCWDeXD8AwSyFl1kponCDgFbrVBwWgv5YvS0lvgTnRo65ix2g/XhVCeqLmgb42t5lnA+QSoRmY21CGalMF1JNvzMwhRr0ZTslbr/OUphjumFylhRcH89QX5HD1UZcq/tbECWsenQiVycN/4iKA0tebCQVyfiqC9yf0A0cKgl4G2gyAO1nN0iZ/5k8zBglcmAksi8xzfeLpGCs36wYnC9Z+HzvEV6StA="
+url = "https://archive.archlinux.org/packages/l/libbpf/libbpf-1.4.3-1-x86_64.pkg.tar.zst"
+sha256 = "5c265558f023b70a5bf91a18a8ef91ef997b76937aff1e02899e8a564ba9df43"
+signature = "iQIzBAABCgAdFiEE4kC1fixGMLp2ji8m/BtUfI2BcsgFAmZgmLQACgkQ/BtUfI2BcsiYVw/6A4E4pNMMnrAQpVElsIoe5mgGjKFiZSQiveupLzqETBHfR3tEo+4pSd/K5COOg0OcZbnVf0QQhWgAlHZwszQdbiqTO6QRRvs8D19g2cDB1id0QjetR5Psxiblv97nOwsD0VSERBZ7DIeD+ssZJs+q31P9fF9jlzXYWV6tlBvSCNRc3vS7ShpO/oFm4SriKbJb5/luIPA4vY/JkPN/LUn5kEc/mqynt8yX/xTA1cnF23YNQ9lc2J8ZMYi30guLbFlRjeXgjaPYYxjYZ6A8j3ua/06VFEhjgCno6WUqBt2qKwZzcra57SKoUh7COah18rHQN+4IxGAW6LUPTvaghWiMFA2Be/R1itx72S4AlXym9/7KLs1mrG4YEeCbq5XYfhCec3oie0dfyKmOT61QhrymLlu7EwkDG1neqk+xo595up7m18q3tdiCPRx+AQZd9cxM1+wgjje2ZNSLRrP076AEZenLYADxhhnL5Omr70d7mGZooMjMu7J4AWxfWXmFYZYxhaZ9ywbWnfJJhkdFPuczOZU38Am0lCZpRSSPt3IYxTxzpQt3esSzhXIOTzH67P4ef55TeIqojzhdXcX8mr1J0LJGduG91lfMTb7X2tiEq8XAGmYHEpMt4VnfdG+wyMLCQXzHWAu1CzDcxBNft79rJE9xaKC/9550FsBkERN501Q="
 
 [[package]]
 name = "libcap"
@@ -507,11 +523,11 @@ signature = "iHUEABYKAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCZfdwygAKCRBtQr3RFuAGj3a
 
 [[package]]
 name = "libmpc"
-version = "1.3.1-1"
+version = "1.3.1-2"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/l/libmpc/libmpc-1.3.1-1-x86_64.pkg.tar.zst"
-sha256 = "a83324a476cae86887aa3e3811b2e72c31471a81be0254e379c244e2df531c1b"
-signature = "iQEzBAABCAAdFiEEFRnVq6Zb9vwrc8dWek52CV2KUuQFAmOfE/EACgkQek52CV2KUuRNEwf6AkQRJ6MKo3+8qZ5DoL1AUfEbRy332+0DbmhqVAZAVR6SDYwr8yTYc5L9zWtRYA++Nh0zah4P6o3XXJISOfLLpQHGPI1jZ/1IGTJlCt0yo+KU891YfQQO95TCAa77oT9Njkxr6imF0vP5kR3PA5sEvqD0iCu69s0TQu2uzsVqigNmbWU3LVv47BrF1T+C31Oa6cRWmjDUtn2ls/jYn+BPvuCO9TyH/3d2lQ1CCM+H1cCDcxzBSmaYSVQUbM6x8YAdFKDZKEbwuiCGTwKIV5ZRar4UiiBdeuJzF0vSy51VdcZpvf30HU8VuJ2Q+mv5OfyHjt/HBCkEyn1b+XufIqb0Xg=="
+url = "https://archive.archlinux.org/packages/l/libmpc/libmpc-1.3.1-2-x86_64.pkg.tar.zst"
+sha256 = "10554706eb15ed2186fbd55fd5db8fa5919788ac9a75d26c0b9ef5bdfca9d470"
+signature = "iQEzBAABCAAdFiEEFRnVq6Zb9vwrc8dWek52CV2KUuQFAmaHCZwACgkQek52CV2KUuRjbAf/TmL9cCMXYTGsNmR2om6kT7XjczfZoFR9AM0FSTUNy5AuNZNUUCfm6ie6F4rFwHc3nETOSojScOZauZlcNiLrVriHYYFSZ8EhKiCJCo68a7KTbceBNoBuT6AEIpGMpIMti/cvWhu8VXl5JIRo8LNPBzDih05aCDUJ2nayKPYNHalDayu87sDXzJYXuzC8KD7XmUa7Kirn0ZpA4VZXc8CUjYYvn0wvRwLKQP4WMpszxmblQWjMVbQxh7dwC+gPtqIANVjoGKMRfr6QpT03XXIEaTBKbMsxeYFvwn+y2JN30t6oFI6LJADZ22VwimEzu06u+x9c+3+pr4k7Py43OCOGmg=="
 
 [[package]]
 name = "libnetfilter_conntrack"
@@ -650,6 +666,14 @@ sha256 = "90a7b061db393d9a6f68244f8772053f42d6cce586c561200d2586d4d662e504"
 signature = "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCZjoV/l8UgAAAAAAuAChpc3N1ZXItZnByQG5vdGF0aW9ucy5vcGVucGdwLmZpZnRoaG9yc2VtYW4ubmV0MDVDNzc3NUE5RThCOTc3NDA3RkUwOEU2OUQ0QzVBQTE1NDI2REEwQQAKCRCdTFqhVCbaCkbGAQDgE3AKw3Q01iehBZZsnkeeJItviKl5ymy9TKMrSeReXAD/QkZ9wK4v8R09cvnQPHfwnWV8Myhey1EIiDXnaKhp5Qw="
 
 [[package]]
+name = "lmdb"
+version = "0.9.32-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/l/lmdb/lmdb-0.9.32-1-x86_64.pkg.tar.zst"
+sha256 = "474c654b589b25f80b6bed806b6f5b79ff88f2052d9a54848299ef75a23e3dd5"
+signature = "iQIzBAABCAAdFiEEtZcfLFwQqaCMYAMPeGxj8zDXy5IFAmXLraQACgkQeGxj8zDXy5KzBQ//ainnkpc4j/YWOqY5bYu8BcIIrjk8dgEu4zV3w3QVQflJ160/x1vZPdcCsI5Ur3v9+dQvBYWgNfkSIrMNay+JeAkYpQ9a1MCaOlXoSmHmLUiyzVh9zNy5bY8yDDPNFUJf2oEyAKHvUFR7Fs0qxonqfilKKGehkJR1eSbPU1ZmDOcw5sjCHnZ8GUv8+rwoF4TABJnlvAaZ73YKdkmS3IQ+XQI98sv0rKbyLAM0s/ErBeI2WAx0FE9p19uyB5G8GRokFZt96zIqmHNUpCXbWeHmAIVcvDk2s6StHqywS5kEATLkHxLRaPQY2axVeluL/OGeHRyevDW/mYdwJgNa7Nlawgnq5PsyyLAdY310gYtwyx8HAMrhkEGOH1udno2sqmZ4vDpUjeSS1NPZ+4gq2/+Nk8KDlLj96IQHYnhV8PspcSG0Q9WCBWbVQ12r4K2+8XIO9gI8hg5/7kSevNz8Vcamcy84ezJpHZ88m+LpNLDmVL2BiMN6qMhMf+Ka3KeRyUgkDo9nZf9s/JjehkjGiKZJs74YnNzgPnKfeu53l2xyQw/QxG9kB0dOAGsiRFz/VZhuSyWK3cc60lvaMuDFjzSdMCuqAHzZrc0iVD412FZAtgE8Ek8Vi7XXhokwnXOT6Y3rSA5lpJhUPgI56Xfl5lXxD3opFN2shTaCe95KEsjcoag="
+
+[[package]]
 name = "lz4"
 version = "1:1.9.4-3"
 system = "archlinux"
@@ -675,11 +699,19 @@ signature = "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCZjqbXF8UgAAAAAAuAChpc3N
 
 [[package]]
 name = "musl"
-version = "1.2.5-1"
+version = "1.2.5-2"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/m/musl/musl-1.2.5-1-x86_64.pkg.tar.zst"
-sha256 = "914fc5796209750652303e830c6ddc2478ffa27261801592ac49f64a1456bac6"
-signature = "iQJLBAABCAA1FiEEiee5MxxK59f699MFwTIpOVS75K0FAmXjEw8XHHNwdXB5a2luQGFyY2hsaW51eC5vcmcACgkQwTIpOVS75K1yCg/+KLpAazqnCdR0qY6xNJM/v21L8B5Jl6+KIQCZ9NCTn0/33gQBCvMGghcx1WblzEslI6zjq2xHVzO7o2X2c3Vkl/XgsomY/DeXzK/GGVm+4yeyVe/M5CALqnzkHZiqEQvNkUW+7IKMHxmVWeXDhSWEv0k2SwEkl8K+Ge+BK1wdhXoj767YZXuf+09o8e6a4T1tLjauopBE7/7fXYD7/G0/UJueVQrFv72ouujL+Cazpv7vZfJYT8WjmhgPfHxBGKKNYzb9VICSw1jw6O1KAOd6b9j6kA+LkBYMkzFzCrVB3T5QXFSntUv2lBFvX03/E+1uTv3aAoBDFvaE1nveXODl35Tvh8/hyUdiKYjpbAY4nlrgjjgZF7ydL6cmv0KkhGNa6sVLANScKBRGjeGoHVWEIRLIeFG7KUymUPE6Yndak7Y6INr1lDH7gEqiWcVEd+27GstCk4g+dijrIV3PNer3JzJzBNYVxRXaIeIpSgn61tsca0KrmS3kr4j6fwX3K4ILBL4HcCsSCnk2HUFDtBlMiYGACsB/ue10MVmDZF1LDs8jxyrYLviCgR7e6iENAmkbd0UhQniC0vG2HiAJA2K6IYk9btw4ItUtFUdm7OnIcJlIt6LCaa9V3IJ87uZIPNlWCGZxPLPMyByCAGSOOvmYO5U248Sknqs4FFDGKVsrHAo="
+url = "https://archive.archlinux.org/packages/m/musl/musl-1.2.5-2-x86_64.pkg.tar.zst"
+sha256 = "146b60543069d4eb92fd9086ffd6f442ee0a1f41f724445adc29af80693ce2da"
+signature = "iQJLBAABCAA1FiEEiee5MxxK59f699MFwTIpOVS75K0FAmaUdzsXHHNwdXB5a2luQGFyY2hsaW51eC5vcmcACgkQwTIpOVS75K2C+g//ddIjb7CKai01nuuzLd9hZQBP51iBe+lYdhv5lxlKaSzQZXHVUGXDAZdb7TaV9pbzdGPE+l5V2ZngivXdR5twUDWOQzvorXdxLgX7trBTghLDTBIKu6jPtrH2bNWrL8A908RumQVeWsOxUcompgAsRpQ4DhZkzk8325k9et0Nv1oQic96B5G1WefE85IYc2PDJeRhfyfnZmQ15aoVhohyhF0XSudlJSc/hqMZePW8tmyYz4ltvgOs4EF3smNwOaZVOew+w/5vOCYaSre5MFwHiilvYJaWhCji10m0MrBzLhRx0ZfRlBwTGbsToRbmczuwMXoYIiJsI2OiXsZD5/X9T5yPjl7pWP7uLaNTXCcbfrCZIWMVBXYQFxnWhUbKFZu8E7eXU2z75GukkC7GjR+VKw+SFH06Xdq73JltIXURRKe03uigC8ciME1xHOMv5kc1pQukQC/hTaR4GPF32pOX27CPQkNQ0dhRi1Cgyt47V+3GncI+mhlY3gJsCv31+Z0kM+WornVJYFSQnO0/frFPJaZUt0ONO7lHU2UMTe2tHm+zFHuHh6xOGaMjdRslrzq0Pby0xMb6nT0HsT1VXfSW30rywN1UPLd3TxAXGkG3SS8szftrLrmK6NAsK5tWfd5H2tiwSibYNnYYYVB720LKBl7bgpGFicdROohXJKqXsvA="
+
+[[package]]
+name = "musl-aarch64"
+version = "1.2.5-2"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/m/musl-aarch64/musl-aarch64-1.2.5-2-x86_64.pkg.tar.zst"
+sha256 = "a127125a8b889341e8ee1d9a68b75b7afbc7af9a13e0203c460b5bf266084df3"
+signature = "iQJLBAABCAA1FiEEiee5MxxK59f699MFwTIpOVS75K0FAmaUdzwXHHNwdXB5a2luQGFyY2hsaW51eC5vcmcACgkQwTIpOVS75K3i7xAAgtV4szRrzrfudev6aAAIeGUMMmYRuzSjicbS8+2jMdJUTeWkHRpEWkA/f+T29ki9OlJAHzotThWREgetwkoXrovUfugb0MNY++u4Oo3N2Z72AS1ndweWy/0ewz/0sOuVn6NNfTek8BhXa9lzhPLbd+JLRHXqlt4gz6tS8ax9aiXuUqKIqjo00HTfwiMYyaUbRx83eJL/0549A2Rq72Ju7vDIBnRe2Bf5brYkRBluVbOKgEEEDJ63pwzzw2K694YJyIzGmeLf5ZKG2dVyQZ9RoR08bwMXGKt7qInijgbDozNp3GOdvVL/v4wMByc1TjqazycJmSgKqFALgLxBsxm9LjT+j2OCpz5imS4I1OecuJSO5bTHZNhkgE9rqsGdjVNUjLSgvQem/k8OdIWrnF5W7bfCZEI7EUI5qxAG3uh6jCG/LEJkjIuR7IN17sDtl50DcPpN/Sr4wcETXfoz1NNB3b8ZwBITkADBnDu+lmG2+x7pPXicZSVOPN8i1IYnq8r11Aw1GxOCXQZsGfsJgByjWYs5iD1Y/8JLlsw7aagwjZoh2bMGadlA+tzY83+2OP2Nq4Vrhwum96ec7vUoe3kKADJ0751IHW3+anqglMivyOXmngBObAcoWb/Q1HrTMTQy6SGemdM614Yw/h+tJizeOvugkqbX3gny7grDrIgmjRY="
 
 [[package]]
 name = "ncurses"
@@ -864,14 +896,6 @@ system = "archlinux"
 url = "https://archive.archlinux.org/packages/u/util-linux-libs/util-linux-libs-2.40.2-1-x86_64.pkg.tar.zst"
 sha256 = "f2b27ad8987bd146aa9431aec36cbd73b0a820c4996b91cac15afcebd96ea399"
 signature = "iHUEABYKAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCZoZctQAKCRBtQr3RFuAGj94rAP0ZLhpNPjBwnpon0hlXT6gKrRAxiD5BdsDCPjSTA5B2rgEAhjBvxUGHDD2X9meZ0uE8ilKpjjmyQtBWHASwab5VBwo="
-
-[[package]]
-name = "wget"
-version = "1.24.5-3"
-system = "archlinux"
-url = "https://archive.archlinux.org/packages/w/wget/wget-1.24.5-3-x86_64.pkg.tar.zst"
-sha256 = "fd928001f09cf506f5db8614501d49abea2c18e6546140db9bac450cf0e60b80"
-signature = "iHUEABYKAB0WIQRUwf0nM2HqUUojd5Pylr3lA2jGzgUCZnw1DgAKCRDylr3lA2jGzsANAP4zcY+oGqNvPyR4AVVGPESLblBvPrvq2PuUAh5edlgPRAD9EaxkTGK1BxQh5ssBmf3+fvYDnbJjEhy1ZCBWbtriGwU="
 
 [[package]]
 name = "xz"

--- a/pkgs/acme-redirect/repro-env.toml
+++ b/pkgs/acme-redirect/repro-env.toml
@@ -10,7 +10,7 @@ dependencies = [
     "gcc",
     "make",
     "musl",
+    "musl-aarch64",
     "perl",
     "rustup",
-    "wget",
 ]

--- a/pkgs/authoscope/build.toml
+++ b/pkgs/authoscope/build.toml
@@ -21,23 +21,6 @@ set -e
 # 2024-01-01
 export SOURCE_DATE_EPOCH=1704067200
 
-wget https://www.musl-libc.org/releases/musl-1.2.5.tar.gz
-echo 'a9a118bbe84d8764da0ea0d28b3ab3fae8477fc7e4085d90102b8596fc7c75e4  musl-1.2.5.tar.gz' | sha256sum -c -
-tar xf musl-1.2.5.tar.gz
-
-# Arch Linux currently doesn't have cross-compiled musl libc, so we build our own
-pushd musl-1.2.5/
-CROSS_COMPILE="aarch64-linux-gnu-" \
-./configure --prefix=/usr/aarch64-linux-musl/lib/musl \
-  --exec-prefix=/usr/aarch64-linux-musl \
-  --enable-wrapper=all \
-  --target="aarch64-linux-musl" \
-  CFLAGS="-ffat-lto-objects"
-make
-make DESTDIR="/" install
-mv -v /lib/ld-musl-aarch64.so* /usr/aarch64-linux-musl/lib/
-popd
-
 # configure the right linker for cross compile
 mkdir -vp ~/.cargo
 printf '[target.aarch64-unknown-linux-musl]\\nlinker = "/usr/aarch64-linux-musl/bin/musl-gcc"\\n' > ~/.cargo/config.toml

--- a/pkgs/authoscope/repro-env.lock
+++ b/pkgs/authoscope/repro-env.lock
@@ -43,11 +43,11 @@ signature = "iHUEABYKAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCZbDRHwAKCRBtQr3RFuAGj1S
 
 [[package]]
 name = "archlinux-keyring"
-version = "20240609-1"
+version = "20240709-1"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/a/archlinux-keyring/archlinux-keyring-20240609-1-any.pkg.tar.zst"
-sha256 = "1498cbf8f9511a7c4f52b40b392bf8779e9543195f2a0a95a9dcda7b49dd0f9f"
-signature = "iHUEABYKAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCZmYV4QAKCRBtQr3RFuAGj5TKAQC4YJtPS54Mbb1HpkGBtt/rnHcZJwCTGkZ5oyPcWqen+QD+ICYfcLg4P1+sj+hMfPmDXQf4aKBLDrFkKKvSvCgy6wY="
+url = "https://archive.archlinux.org/packages/a/archlinux-keyring/archlinux-keyring-20240709-1-any.pkg.tar.zst"
+sha256 = "a6f573fc97fc21b55504a4d75d010257792847a5b87f19edff4ffb662f6f53a2"
+signature = "iHUEABYKAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCZo2s1wAKCRBtQr3RFuAGj9MSAQDCI730nuxWZ70VM9xGZZZDyLwb6LdAN+fbUdkNzaE3wAEAsNqHKFnUKRnBXwGOv3j8VrP+XaGD0P2QJAEocEeWiQM="
 
 [[package]]
 name = "attr"
@@ -258,6 +258,14 @@ sha256 = "7605cb1ab1830dbdd564591d33adeec78ce79c1733bd98f36ba3e81eb9748b78"
 signature = "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCZk3zsF8UgAAAAAAuAChpc3N1ZXItZnByQG5vdGF0aW9ucy5vcGVucGdwLmZpZnRoaG9yc2VtYW4ubmV0MDVDNzc3NUE5RThCOTc3NDA3RkUwOEU2OUQ0QzVBQTE1NDI2REEwQQAKCRCdTFqhVCbaCugeAQDgJyrXuoZnSZFU/gz5rGccNOuGSgOvfYX2YTY1drfb/AEA4pmZIr4MJC/1XQF5AmrhxTX491TtbJgxdstI+1KysAs="
 
 [[package]]
+name = "gdbm"
+version = "1.24-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/g/gdbm/gdbm-1.24-1-x86_64.pkg.tar.zst"
+sha256 = "2712f2747f887ff19ad4151143e506e80254a0a0db0e8b968adb6634da7800ab"
+signature = "iHUEABYKAB0WIQRizHP4hOUpV7L92IObeih9mi7GCAUCZoa2fgAKCRCbeih9mi7GCKXhAQDIaNqIfZ2hIa29L7FE1axM7Ui45KQxU/XOCC2cnzisvAD/aecNLEqMxSnE/FsOhZdi0dAHLAuOjVRSpF6IbtF1NgM="
+
+[[package]]
 name = "gettext"
 version = "0.22.5-1"
 system = "archlinux"
@@ -267,11 +275,11 @@ signature = "iQEzBAABCAAdFiEEW34/txt/EDKaHAOrdx32Yn7faB8FAmY7WIYACgkQdx32Yn7faB9
 
 [[package]]
 name = "glib2"
-version = "2.80.3-2"
+version = "2.80.4-1"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/g/glib2/glib2-2.80.3-2-x86_64.pkg.tar.zst"
-sha256 = "5097ae4a68ce205c4ffa370d5d9ba3e4ad9afb97d61e3d3f61d9b944813e7ad4"
-signature = "iHUEABYKAB0WIQSDvIiJNRtd67toQW64rAhgDxCM3wUCZmjHogAKCRC4rAhgDxCM30ONAQDMZoZSkJDOZDPD9PMLvhbK1VJxJp8VRgdxG1OILR9kfAD/evaIoFqw0LCQaTkKdSavJURgzmjh9g+LJ4FM7OnIzwA="
+url = "https://archive.archlinux.org/packages/g/glib2/glib2-2.80.4-1-x86_64.pkg.tar.zst"
+sha256 = "047121788777ae88726ee10525fba0ab05cc495cdb336a45bea6cdd0793c8d06"
+signature = "iHUEABYKAB0WIQSDvIiJNRtd67toQW64rAhgDxCM3wUCZoxhigAKCRC4rAhgDxCM37jmAQCMi355gHS4atKFg2Zr5R5hElvjlTp2vx7s2MniqS4usAD+KrBXRueBCElmnuplANh2d71qDwjAG7FFueZk8bp61wA="
 
 [[package]]
 name = "glibc"
@@ -394,6 +402,14 @@ sha256 = "9abd6fd54052b48b2bac6e709e25e7be876f68d84949ed4615a3fb8803f2a736"
 signature = "iHUEABYKAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCZegwsQAKCRBtQr3RFuAGj3QXAQDqrsXu36gY3rprKLSh3b3O0VYDQk7UHHSCAveZEHpvxQD/dR6SLukPahSQ8LABJmCFHk4w4d1PgBDRCczcaMYR2QE="
 
 [[package]]
+name = "krb5"
+version = "1.21.3-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/k/krb5/krb5-1.21.3-1-x86_64.pkg.tar.zst"
+sha256 = "7ce8f30ccef0650b964defb7a539c72d5e40fcd288f5f397c1b824d3f4431b2b"
+signature = "iQIzBAABCgAdFiEE4kC1fixGMLp2ji8m/BtUfI2BcsgFAmaJc6UACgkQ/BtUfI2BcsjO0w//R4djAXEL1QcOF/Jh4Ukqy+k+AhvnNSJN5JPhOkvJKc7DqCudBaFcuHdGno6KIAyg42q9PjeIBWxH2kcIVojmGZ+zPvscdX0mjwJAxZ+tBDfa54eOqtnUMGbPDL5QoGeZjfhdQ0hHOFDkpioz8c1hVjdTRvqkC6J5uUGH2SQmD9HfBUFv5O9g/QW+JJI4kXFYnewZewrDOFAccYFjcBjioY1L898+2freJ2JOIh5acf1mtQol/cZhOQevQ/SdZ+BsYZOLp3QFU+IE4Wg+3h2ayEa88A7i/U6ln03GkYNySY1UmqKwrALE9ixW8BSKXoVldtjyiLFH1PHsr0QLmn1IBEt0bis5L059JEdaCv8JKeEElQORUQNLXS6fBV/Oo4oc6mI0SiyOvMPchwkrgvSkh2UKz4AGtpan5EvwRDdaNdhZiCVEDWLIZ6sm0sXRIoJzrB4SsCux9eZnma6Yls47PjgR75ZFbNCr/CHHpZMHyL7mjb8fpZl12mXRcRAMo+3laZsJxUUOymtf3gb/SKQ5rDlYfHxtFaoRvUzKOscUT1d5PQ90KAuD0rbRmUynxBd4FqLAPs7xpcFJtboAsLd1Iax04gAxNtmQQ9F2SujJD+h/LoPwtqu2rU07e9+rcXtKqwYqTxH8TDGpEERsxkUcaLkvsz3sOxIEAUzubYnBn4I="
+
+[[package]]
 name = "libarchive"
 version = "3.7.4-1"
 system = "archlinux"
@@ -411,11 +427,11 @@ signature = "iHUEABYKAB0WIQRizHP4hOUpV7L92IObeih9mi7GCAUCZgqJbQAKCRCbeih9mi7GCNv
 
 [[package]]
 name = "libbpf"
-version = "1.4.2-1"
+version = "1.4.3-1"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/l/libbpf/libbpf-1.4.2-1-x86_64.pkg.tar.zst"
-sha256 = "70e86fd8bf8e6a0850eed15a580376049d988a28e987afa4c311abd2b1af611c"
-signature = "iQIzBAABCgAdFiEE4kC1fixGMLp2ji8m/BtUfI2BcsgFAmZSc7YACgkQ/BtUfI2Bcsg/HBAAu1v9RTktILD/N34CyIuLCDci6qPeEC3oXDIpZLBnXTwcIwo2Hhhn5n3Sz+k/Tbb6gRMIRhsnqwpxANRo38B9QMODyfeM4wKDNusV1cYUtE/9X3g00dHOYwDu//a/eLj7vHnUWTnFT3zebtRqFUtsFCKr1gogppkQzKCuYx7Nhrl/Z/1md7LEQZXxKWt9d4VSjex4noNMu+7ZujWKZFfYjyPyBzX2mDe96VEBT8BGnMzMjHT07Z7094BAHmVBrNmaJYxkNn34zhMAnG03Lxq93RHgnRJ3K7yzx+rRuEwsqg+7w/47nvgq6K0EaB04jQ6HbW/uIAn3sWIYgMZFIeBxeiCn5qQsNH0u7kSy3fivVuKADmVNG7UphHa3CVcSUi+9nSgt7Ug1RM3vsfX6c/+OiJnQoDHl/ITNZTsmMjc+H0jcJf+3zHyLnKObgEDOTehixOHWUnA8I0MgGCWDeXD8AwSyFl1kponCDgFbrVBwWgv5YvS0lvgTnRo65ix2g/XhVCeqLmgb42t5lnA+QSoRmY21CGalMF1JNvzMwhRr0ZTslbr/OUphjumFylhRcH89QX5HD1UZcq/tbECWsenQiVycN/4iKA0tebCQVyfiqC9yf0A0cKgl4G2gyAO1nN0iZ/5k8zBglcmAksi8xzfeLpGCs36wYnC9Z+HzvEV6StA="
+url = "https://archive.archlinux.org/packages/l/libbpf/libbpf-1.4.3-1-x86_64.pkg.tar.zst"
+sha256 = "5c265558f023b70a5bf91a18a8ef91ef997b76937aff1e02899e8a564ba9df43"
+signature = "iQIzBAABCgAdFiEE4kC1fixGMLp2ji8m/BtUfI2BcsgFAmZgmLQACgkQ/BtUfI2BcsiYVw/6A4E4pNMMnrAQpVElsIoe5mgGjKFiZSQiveupLzqETBHfR3tEo+4pSd/K5COOg0OcZbnVf0QQhWgAlHZwszQdbiqTO6QRRvs8D19g2cDB1id0QjetR5Psxiblv97nOwsD0VSERBZ7DIeD+ssZJs+q31P9fF9jlzXYWV6tlBvSCNRc3vS7ShpO/oFm4SriKbJb5/luIPA4vY/JkPN/LUn5kEc/mqynt8yX/xTA1cnF23YNQ9lc2J8ZMYi30guLbFlRjeXgjaPYYxjYZ6A8j3ua/06VFEhjgCno6WUqBt2qKwZzcra57SKoUh7COah18rHQN+4IxGAW6LUPTvaghWiMFA2Be/R1itx72S4AlXym9/7KLs1mrG4YEeCbq5XYfhCec3oie0dfyKmOT61QhrymLlu7EwkDG1neqk+xo595up7m18q3tdiCPRx+AQZd9cxM1+wgjje2ZNSLRrP076AEZenLYADxhhnL5Omr70d7mGZooMjMu7J4AWxfWXmFYZYxhaZ9ywbWnfJJhkdFPuczOZU38Am0lCZpRSSPt3IYxTxzpQt3esSzhXIOTzH67P4ef55TeIqojzhdXcX8mr1J0LJGduG91lfMTb7X2tiEq8XAGmYHEpMt4VnfdG+wyMLCQXzHWAu1CzDcxBNft79rJE9xaKC/9550FsBkERN501Q="
 
 [[package]]
 name = "libcap"
@@ -507,11 +523,11 @@ signature = "iHUEABYKAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCZfdwygAKCRBtQr3RFuAGj3a
 
 [[package]]
 name = "libmpc"
-version = "1.3.1-1"
+version = "1.3.1-2"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/l/libmpc/libmpc-1.3.1-1-x86_64.pkg.tar.zst"
-sha256 = "a83324a476cae86887aa3e3811b2e72c31471a81be0254e379c244e2df531c1b"
-signature = "iQEzBAABCAAdFiEEFRnVq6Zb9vwrc8dWek52CV2KUuQFAmOfE/EACgkQek52CV2KUuRNEwf6AkQRJ6MKo3+8qZ5DoL1AUfEbRy332+0DbmhqVAZAVR6SDYwr8yTYc5L9zWtRYA++Nh0zah4P6o3XXJISOfLLpQHGPI1jZ/1IGTJlCt0yo+KU891YfQQO95TCAa77oT9Njkxr6imF0vP5kR3PA5sEvqD0iCu69s0TQu2uzsVqigNmbWU3LVv47BrF1T+C31Oa6cRWmjDUtn2ls/jYn+BPvuCO9TyH/3d2lQ1CCM+H1cCDcxzBSmaYSVQUbM6x8YAdFKDZKEbwuiCGTwKIV5ZRar4UiiBdeuJzF0vSy51VdcZpvf30HU8VuJ2Q+mv5OfyHjt/HBCkEyn1b+XufIqb0Xg=="
+url = "https://archive.archlinux.org/packages/l/libmpc/libmpc-1.3.1-2-x86_64.pkg.tar.zst"
+sha256 = "10554706eb15ed2186fbd55fd5db8fa5919788ac9a75d26c0b9ef5bdfca9d470"
+signature = "iQEzBAABCAAdFiEEFRnVq6Zb9vwrc8dWek52CV2KUuQFAmaHCZwACgkQek52CV2KUuRjbAf/TmL9cCMXYTGsNmR2om6kT7XjczfZoFR9AM0FSTUNy5AuNZNUUCfm6ie6F4rFwHc3nETOSojScOZauZlcNiLrVriHYYFSZ8EhKiCJCo68a7KTbceBNoBuT6AEIpGMpIMti/cvWhu8VXl5JIRo8LNPBzDih05aCDUJ2nayKPYNHalDayu87sDXzJYXuzC8KD7XmUa7Kirn0ZpA4VZXc8CUjYYvn0wvRwLKQP4WMpszxmblQWjMVbQxh7dwC+gPtqIANVjoGKMRfr6QpT03XXIEaTBKbMsxeYFvwn+y2JN30t6oFI6LJADZ22VwimEzu06u+x9c+3+pr4k7Py43OCOGmg=="
 
 [[package]]
 name = "libnetfilter_conntrack"
@@ -650,6 +666,14 @@ sha256 = "90a7b061db393d9a6f68244f8772053f42d6cce586c561200d2586d4d662e504"
 signature = "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCZjoV/l8UgAAAAAAuAChpc3N1ZXItZnByQG5vdGF0aW9ucy5vcGVucGdwLmZpZnRoaG9yc2VtYW4ubmV0MDVDNzc3NUE5RThCOTc3NDA3RkUwOEU2OUQ0QzVBQTE1NDI2REEwQQAKCRCdTFqhVCbaCkbGAQDgE3AKw3Q01iehBZZsnkeeJItviKl5ymy9TKMrSeReXAD/QkZ9wK4v8R09cvnQPHfwnWV8Myhey1EIiDXnaKhp5Qw="
 
 [[package]]
+name = "lmdb"
+version = "0.9.32-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/l/lmdb/lmdb-0.9.32-1-x86_64.pkg.tar.zst"
+sha256 = "474c654b589b25f80b6bed806b6f5b79ff88f2052d9a54848299ef75a23e3dd5"
+signature = "iQIzBAABCAAdFiEEtZcfLFwQqaCMYAMPeGxj8zDXy5IFAmXLraQACgkQeGxj8zDXy5KzBQ//ainnkpc4j/YWOqY5bYu8BcIIrjk8dgEu4zV3w3QVQflJ160/x1vZPdcCsI5Ur3v9+dQvBYWgNfkSIrMNay+JeAkYpQ9a1MCaOlXoSmHmLUiyzVh9zNy5bY8yDDPNFUJf2oEyAKHvUFR7Fs0qxonqfilKKGehkJR1eSbPU1ZmDOcw5sjCHnZ8GUv8+rwoF4TABJnlvAaZ73YKdkmS3IQ+XQI98sv0rKbyLAM0s/ErBeI2WAx0FE9p19uyB5G8GRokFZt96zIqmHNUpCXbWeHmAIVcvDk2s6StHqywS5kEATLkHxLRaPQY2axVeluL/OGeHRyevDW/mYdwJgNa7Nlawgnq5PsyyLAdY310gYtwyx8HAMrhkEGOH1udno2sqmZ4vDpUjeSS1NPZ+4gq2/+Nk8KDlLj96IQHYnhV8PspcSG0Q9WCBWbVQ12r4K2+8XIO9gI8hg5/7kSevNz8Vcamcy84ezJpHZ88m+LpNLDmVL2BiMN6qMhMf+Ka3KeRyUgkDo9nZf9s/JjehkjGiKZJs74YnNzgPnKfeu53l2xyQw/QxG9kB0dOAGsiRFz/VZhuSyWK3cc60lvaMuDFjzSdMCuqAHzZrc0iVD412FZAtgE8Ek8Vi7XXhokwnXOT6Y3rSA5lpJhUPgI56Xfl5lXxD3opFN2shTaCe95KEsjcoag="
+
+[[package]]
 name = "lz4"
 version = "1:1.9.4-3"
 system = "archlinux"
@@ -675,11 +699,19 @@ signature = "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCZjqbXF8UgAAAAAAuAChpc3N
 
 [[package]]
 name = "musl"
-version = "1.2.5-1"
+version = "1.2.5-2"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/m/musl/musl-1.2.5-1-x86_64.pkg.tar.zst"
-sha256 = "914fc5796209750652303e830c6ddc2478ffa27261801592ac49f64a1456bac6"
-signature = "iQJLBAABCAA1FiEEiee5MxxK59f699MFwTIpOVS75K0FAmXjEw8XHHNwdXB5a2luQGFyY2hsaW51eC5vcmcACgkQwTIpOVS75K1yCg/+KLpAazqnCdR0qY6xNJM/v21L8B5Jl6+KIQCZ9NCTn0/33gQBCvMGghcx1WblzEslI6zjq2xHVzO7o2X2c3Vkl/XgsomY/DeXzK/GGVm+4yeyVe/M5CALqnzkHZiqEQvNkUW+7IKMHxmVWeXDhSWEv0k2SwEkl8K+Ge+BK1wdhXoj767YZXuf+09o8e6a4T1tLjauopBE7/7fXYD7/G0/UJueVQrFv72ouujL+Cazpv7vZfJYT8WjmhgPfHxBGKKNYzb9VICSw1jw6O1KAOd6b9j6kA+LkBYMkzFzCrVB3T5QXFSntUv2lBFvX03/E+1uTv3aAoBDFvaE1nveXODl35Tvh8/hyUdiKYjpbAY4nlrgjjgZF7ydL6cmv0KkhGNa6sVLANScKBRGjeGoHVWEIRLIeFG7KUymUPE6Yndak7Y6INr1lDH7gEqiWcVEd+27GstCk4g+dijrIV3PNer3JzJzBNYVxRXaIeIpSgn61tsca0KrmS3kr4j6fwX3K4ILBL4HcCsSCnk2HUFDtBlMiYGACsB/ue10MVmDZF1LDs8jxyrYLviCgR7e6iENAmkbd0UhQniC0vG2HiAJA2K6IYk9btw4ItUtFUdm7OnIcJlIt6LCaa9V3IJ87uZIPNlWCGZxPLPMyByCAGSOOvmYO5U248Sknqs4FFDGKVsrHAo="
+url = "https://archive.archlinux.org/packages/m/musl/musl-1.2.5-2-x86_64.pkg.tar.zst"
+sha256 = "146b60543069d4eb92fd9086ffd6f442ee0a1f41f724445adc29af80693ce2da"
+signature = "iQJLBAABCAA1FiEEiee5MxxK59f699MFwTIpOVS75K0FAmaUdzsXHHNwdXB5a2luQGFyY2hsaW51eC5vcmcACgkQwTIpOVS75K2C+g//ddIjb7CKai01nuuzLd9hZQBP51iBe+lYdhv5lxlKaSzQZXHVUGXDAZdb7TaV9pbzdGPE+l5V2ZngivXdR5twUDWOQzvorXdxLgX7trBTghLDTBIKu6jPtrH2bNWrL8A908RumQVeWsOxUcompgAsRpQ4DhZkzk8325k9et0Nv1oQic96B5G1WefE85IYc2PDJeRhfyfnZmQ15aoVhohyhF0XSudlJSc/hqMZePW8tmyYz4ltvgOs4EF3smNwOaZVOew+w/5vOCYaSre5MFwHiilvYJaWhCji10m0MrBzLhRx0ZfRlBwTGbsToRbmczuwMXoYIiJsI2OiXsZD5/X9T5yPjl7pWP7uLaNTXCcbfrCZIWMVBXYQFxnWhUbKFZu8E7eXU2z75GukkC7GjR+VKw+SFH06Xdq73JltIXURRKe03uigC8ciME1xHOMv5kc1pQukQC/hTaR4GPF32pOX27CPQkNQ0dhRi1Cgyt47V+3GncI+mhlY3gJsCv31+Z0kM+WornVJYFSQnO0/frFPJaZUt0ONO7lHU2UMTe2tHm+zFHuHh6xOGaMjdRslrzq0Pby0xMb6nT0HsT1VXfSW30rywN1UPLd3TxAXGkG3SS8szftrLrmK6NAsK5tWfd5H2tiwSibYNnYYYVB720LKBl7bgpGFicdROohXJKqXsvA="
+
+[[package]]
+name = "musl-aarch64"
+version = "1.2.5-2"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/m/musl-aarch64/musl-aarch64-1.2.5-2-x86_64.pkg.tar.zst"
+sha256 = "a127125a8b889341e8ee1d9a68b75b7afbc7af9a13e0203c460b5bf266084df3"
+signature = "iQJLBAABCAA1FiEEiee5MxxK59f699MFwTIpOVS75K0FAmaUdzwXHHNwdXB5a2luQGFyY2hsaW51eC5vcmcACgkQwTIpOVS75K3i7xAAgtV4szRrzrfudev6aAAIeGUMMmYRuzSjicbS8+2jMdJUTeWkHRpEWkA/f+T29ki9OlJAHzotThWREgetwkoXrovUfugb0MNY++u4Oo3N2Z72AS1ndweWy/0ewz/0sOuVn6NNfTek8BhXa9lzhPLbd+JLRHXqlt4gz6tS8ax9aiXuUqKIqjo00HTfwiMYyaUbRx83eJL/0549A2Rq72Ju7vDIBnRe2Bf5brYkRBluVbOKgEEEDJ63pwzzw2K694YJyIzGmeLf5ZKG2dVyQZ9RoR08bwMXGKt7qInijgbDozNp3GOdvVL/v4wMByc1TjqazycJmSgKqFALgLxBsxm9LjT+j2OCpz5imS4I1OecuJSO5bTHZNhkgE9rqsGdjVNUjLSgvQem/k8OdIWrnF5W7bfCZEI7EUI5qxAG3uh6jCG/LEJkjIuR7IN17sDtl50DcPpN/Sr4wcETXfoz1NNB3b8ZwBITkADBnDu+lmG2+x7pPXicZSVOPN8i1IYnq8r11Aw1GxOCXQZsGfsJgByjWYs5iD1Y/8JLlsw7aagwjZoh2bMGadlA+tzY83+2OP2Nq4Vrhwum96ec7vUoe3kKADJ0751IHW3+anqglMivyOXmngBObAcoWb/Q1HrTMTQy6SGemdM614Yw/h+tJizeOvugkqbX3gny7grDrIgmjRY="
 
 [[package]]
 name = "ncurses"
@@ -864,14 +896,6 @@ system = "archlinux"
 url = "https://archive.archlinux.org/packages/u/util-linux-libs/util-linux-libs-2.40.2-1-x86_64.pkg.tar.zst"
 sha256 = "f2b27ad8987bd146aa9431aec36cbd73b0a820c4996b91cac15afcebd96ea399"
 signature = "iHUEABYKAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCZoZctQAKCRBtQr3RFuAGj94rAP0ZLhpNPjBwnpon0hlXT6gKrRAxiD5BdsDCPjSTA5B2rgEAhjBvxUGHDD2X9meZ0uE8ilKpjjmyQtBWHASwab5VBwo="
-
-[[package]]
-name = "wget"
-version = "1.24.5-3"
-system = "archlinux"
-url = "https://archive.archlinux.org/packages/w/wget/wget-1.24.5-3-x86_64.pkg.tar.zst"
-sha256 = "fd928001f09cf506f5db8614501d49abea2c18e6546140db9bac450cf0e60b80"
-signature = "iHUEABYKAB0WIQRUwf0nM2HqUUojd5Pylr3lA2jGzgUCZnw1DgAKCRDylr3lA2jGzsANAP4zcY+oGqNvPyR4AVVGPESLblBvPrvq2PuUAh5edlgPRAD9EaxkTGK1BxQh5ssBmf3+fvYDnbJjEhy1ZCBWbtriGwU="
 
 [[package]]
 name = "xz"

--- a/pkgs/authoscope/repro-env.toml
+++ b/pkgs/authoscope/repro-env.toml
@@ -10,7 +10,7 @@ dependencies = [
     "gcc",
     "make",
     "musl",
+    "musl-aarch64",
     "perl",
     "rustup",
-    "wget",
 ]

--- a/pkgs/sh4d0wup/build.toml
+++ b/pkgs/sh4d0wup/build.toml
@@ -18,22 +18,6 @@ checksum = "sha256:..."
 cmd = """
 set -e
 
-wget https://www.musl-libc.org/releases/musl-1.2.5.tar.gz
-echo 'a9a118bbe84d8764da0ea0d28b3ab3fae8477fc7e4085d90102b8596fc7c75e4  musl-1.2.5.tar.gz' | sha256sum -c -
-tar xf musl-1.2.5.tar.gz
-
-pushd musl-1.2.5/
-CROSS_COMPILE="aarch64-linux-gnu-" \
-./configure --prefix=/usr/aarch64-linux-musl/lib/musl \
-  --exec-prefix=/usr/aarch64-linux-musl \
-  --enable-wrapper=all \
-  --target="aarch64-linux-musl" \
-  CFLAGS="-ffat-lto-objects"
-make
-make DESTDIR="/" install
-mv -v /lib/ld-musl-aarch64.so* /usr/aarch64-linux-musl/lib/
-popd
-
 mkdir -vp ~/.cargo
 printf '[target.aarch64-unknown-linux-musl]\\nlinker = "/usr/aarch64-linux-musl/bin/musl-gcc"\\n' > ~/.cargo/config.toml
 

--- a/pkgs/sh4d0wup/repro-env.lock
+++ b/pkgs/sh4d0wup/repro-env.lock
@@ -43,11 +43,11 @@ signature = "iHUEABYKAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCZbDRHwAKCRBtQr3RFuAGj1S
 
 [[package]]
 name = "archlinux-keyring"
-version = "20240609-1"
+version = "20240709-1"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/a/archlinux-keyring/archlinux-keyring-20240609-1-any.pkg.tar.zst"
-sha256 = "1498cbf8f9511a7c4f52b40b392bf8779e9543195f2a0a95a9dcda7b49dd0f9f"
-signature = "iHUEABYKAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCZmYV4QAKCRBtQr3RFuAGj5TKAQC4YJtPS54Mbb1HpkGBtt/rnHcZJwCTGkZ5oyPcWqen+QD+ICYfcLg4P1+sj+hMfPmDXQf4aKBLDrFkKKvSvCgy6wY="
+url = "https://archive.archlinux.org/packages/a/archlinux-keyring/archlinux-keyring-20240709-1-any.pkg.tar.zst"
+sha256 = "a6f573fc97fc21b55504a4d75d010257792847a5b87f19edff4ffb662f6f53a2"
+signature = "iHUEABYKAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCZo2s1wAKCRBtQr3RFuAGj9MSAQDCI730nuxWZ70VM9xGZZZDyLwb6LdAN+fbUdkNzaE3wAEAsNqHKFnUKRnBXwGOv3j8VrP+XaGD0P2QJAEocEeWiQM="
 
 [[package]]
 name = "attr"
@@ -123,11 +123,11 @@ signature = "iHUEABYKAB0WIQSDvIiJNRtd67toQW64rAhgDxCM3wUCZnHT6wAKCRC4rAhgDxCM32T
 
 [[package]]
 name = "cargo-deb"
-version = "2.3.0-1"
+version = "2.4.0-1"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/c/cargo-deb/cargo-deb-2.3.0-1-x86_64.pkg.tar.zst"
-sha256 = "537a26f5a9b057689f42b7b37cb903c95ac0b982908e237e20a652c577246fbe"
-signature = "iQIzBAABCAAdFiEEFl4P98SMIm4ew2On+DQkgks+S5AFAmZrA44ACgkQ+DQkgks+S5AOeA/9FVP0P9inRSQTYfG9VphaTxS2MIB6+HPOR5AaV5z/M0fSO8ux92vtbQcWMKrccttwk5rL6evxJAkMzYSXRJ9Gdua1yYCO8yJ+kr1rffvG/SafCBsnkvoyM+2CAgSwnBWDkWUm7MljyyyNMswcj3WIIrikdJVAKzanzSONlCeioF+zZM1ODZe1N4GVA3A9JlbDuAFVJkzlpqPkLYLr6iAPYyLjHpbPfOhnyDcTJDoDmH8kUWGXPt2W2J7OIIRtrYmUpevG0AS5X6+D37dxmi3qtxeZPnskUiSZ6kbdHLhdAQnte8XkfRUYZ+LtU/YBzjbC5QiKj/9RE/2Rp7NkcdJk/MreolKhQqbVYFNzKYeJamJaNj63fSGKL3X83NYY62w0tS89qRv1AklbLU84Ilutw3YaBTmdlyVSvzYSmfqMie7w3brwQAVRGysyvdMh3K9gMoGZuXpDXE08PQwWtY1h9Q1MmSx8bKWg60VEyLhS3SK5/PjvuS3/6YGgQa1Wxy6lIqSY1wKRg6WlyU+RM8S9Dl5Gtlr6jYAJvkFKgEy1It7UdR5vhPw+DQfb9LIzJnON644qteOhCKJQIEH/JGGH820V3Gq+20jPXjYb7oQoqimnB52yJI53FY/jdX3OsCpE7fojqpBWeLLZ2KKBcSsqwBO2hpNojnuOtCJZyw23BF4="
+url = "https://archive.archlinux.org/packages/c/cargo-deb/cargo-deb-2.4.0-1-x86_64.pkg.tar.zst"
+sha256 = "6b0a76d71961c376129b79d81d318ce9cb401dd21796bf642b8950092cc559c7"
+signature = "iQIzBAABCAAdFiEEM+u4qOHFZTZFsSMqRaZQ4mOMU20FAmaLye4ACgkQRaZQ4mOMU21+Sg//SneMbZek0hl1LONnsp1BkJ4OAxHD8KZ7ZUVgNqoKxFo7Y/vyEnY1QKo6BLTikH6MheSvXhWpdLpNnqXEJj8QA46HNCjaU8rugq0EPJ3meB8I+7qnlelCTwNWIB12UVvOjCm1mR5ux96W/BZjN3Ur7jfQlEHjYsM6ToL+tq2HitkNdQvKO0L6dyQC3FbfqZsi37nBdv7gQKh5IjV0beZ6RReEyEuzBC1Uio3HN3IuStZMSmxiXgpITjwLkHHztNFub0hhQO69065l4CFueqci0aNtkp5xoXF8Qflwui9f0MdxUc8m/5sdf95NTDFWnyh8MnUs3/qqPY6FyQ1uaaf8TxGspO0AQYzkLthe50wEd9aChCinU3x8/17p909u70fGVU6eBqMPugXwzrrHGOJ8JLviUQuGC8kOWvtuEt9oRHnwetWCMVWNcUVHCIl4GG5DBzHPeNP9li8TSoHW8RV7EbxVEtzSnfXxWh3tBRfau0ugxgVlmC7Dn+/wt5PxAXIGZP7MqmRyzBJYVG7vWBHdPFzUEJD0n0dL8IwOWOvbhG4cZ6yfiGHt3yzgbrIMUsDsqdeS8B7EteyAWmNaAkTiuiV58qsy6IfE86b//hfq/NlpKRzuDx+vVlJAYoEfZBblw6k3txlDb1YHc6NQ4PeVFTnQKNDb+WFMSoai4OPxEjg="
 
 [[package]]
 name = "coreutils"
@@ -226,14 +226,6 @@ sha256 = "f7d9994d70d5bac0e99a66508673abba271d1b0b0598e001b7a677d182663500"
 signature = "iQEzBAABCAAdFiEEW34/txt/EDKaHAOrdx32Yn7faB8FAmZbgL0ACgkQdx32Yn7faB8F/ggAt6EqPhQ7KsinXsEEJhE+ammbeflgv4eKpmhP6wlfnb0Cg3TerAKdEbXUdR3rpcztE2f/zLJ+Fs9dYV5DOqcMV5cpLWD0NYjo/SmiZMVjM1/ZWskbnhyMAsfDQwUXXZYruMiOGdMpJFu8sqKBkQqrd4cOkn3AF2r2wXW+PF2r2yb0K9mv6YW285RIEo7aphVsI0LZgKbrksDeMbWQF3U3A1WHrVX1rDXPB0CSnxkIaEm3erzaFj8dhrFd4/7k7iIUjLFP2Ev6HhBjr0CA7V62LtJ9EOyGtYCY7SB4SKL8EWdWJK513jpVe6gu/5M5A3H0zmA8w5E83zW/Z5nbZvnFkQ=="
 
 [[package]]
-name = "gc"
-version = "8.2.6-1"
-system = "archlinux"
-url = "https://archive.archlinux.org/packages/g/gc/gc-8.2.6-1-x86_64.pkg.tar.zst"
-sha256 = "6210a1e7e00d3162f175f9ab318a3da928495210b1ea411dcb66bf5e1f382daf"
-signature = "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCZb9oiF8UgAAAAAAuAChpc3N1ZXItZnByQG5vdGF0aW9ucy5vcGVucGdwLmZpZnRoaG9yc2VtYW4ubmV0MDVDNzc3NUE5RThCOTc3NDA3RkUwOEU2OUQ0QzVBQTE1NDI2REEwQQAKCRCdTFqhVCbaCmQdAP0fleaFihboUqrAdlMxvO5OUJiXXxLtimhQj2e3rD9L3gEA0YzMCzi4GS6GlV1pa/hZ68bPL2gYz2goni9/aLXhMwY="
-
-[[package]]
 name = "gcc"
 version = "14.1.1+r58+gfc9fb69ad62-1"
 system = "archlinux"
@@ -250,6 +242,14 @@ sha256 = "7605cb1ab1830dbdd564591d33adeec78ce79c1733bd98f36ba3e81eb9748b78"
 signature = "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCZk3zsF8UgAAAAAAuAChpc3N1ZXItZnByQG5vdGF0aW9ucy5vcGVucGdwLmZpZnRoaG9yc2VtYW4ubmV0MDVDNzc3NUE5RThCOTc3NDA3RkUwOEU2OUQ0QzVBQTE1NDI2REEwQQAKCRCdTFqhVCbaCugeAQDgJyrXuoZnSZFU/gz5rGccNOuGSgOvfYX2YTY1drfb/AEA4pmZIr4MJC/1XQF5AmrhxTX491TtbJgxdstI+1KysAs="
 
 [[package]]
+name = "gdbm"
+version = "1.24-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/g/gdbm/gdbm-1.24-1-x86_64.pkg.tar.zst"
+sha256 = "2712f2747f887ff19ad4151143e506e80254a0a0db0e8b968adb6634da7800ab"
+signature = "iHUEABYKAB0WIQRizHP4hOUpV7L92IObeih9mi7GCAUCZoa2fgAKCRCbeih9mi7GCKXhAQDIaNqIfZ2hIa29L7FE1axM7Ui45KQxU/XOCC2cnzisvAD/aecNLEqMxSnE/FsOhZdi0dAHLAuOjVRSpF6IbtF1NgM="
+
+[[package]]
 name = "gettext"
 version = "0.22.5-1"
 system = "archlinux"
@@ -259,11 +259,11 @@ signature = "iQEzBAABCAAdFiEEW34/txt/EDKaHAOrdx32Yn7faB8FAmY7WIYACgkQdx32Yn7faB9
 
 [[package]]
 name = "glib2"
-version = "2.80.3-2"
+version = "2.80.4-1"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/g/glib2/glib2-2.80.3-2-x86_64.pkg.tar.zst"
-sha256 = "5097ae4a68ce205c4ffa370d5d9ba3e4ad9afb97d61e3d3f61d9b944813e7ad4"
-signature = "iHUEABYKAB0WIQSDvIiJNRtd67toQW64rAhgDxCM3wUCZmjHogAKCRC4rAhgDxCM30ONAQDMZoZSkJDOZDPD9PMLvhbK1VJxJp8VRgdxG1OILR9kfAD/evaIoFqw0LCQaTkKdSavJURgzmjh9g+LJ4FM7OnIzwA="
+url = "https://archive.archlinux.org/packages/g/glib2/glib2-2.80.4-1-x86_64.pkg.tar.zst"
+sha256 = "047121788777ae88726ee10525fba0ab05cc495cdb336a45bea6cdd0793c8d06"
+signature = "iHUEABYKAB0WIQSDvIiJNRtd67toQW64rAhgDxCM3wUCZoxhigAKCRC4rAhgDxCM37jmAQCMi355gHS4atKFg2Zr5R5hElvjlTp2vx7s2MniqS4usAD+KrBXRueBCElmnuplANh2d71qDwjAG7FFueZk8bp61wA="
 
 [[package]]
 name = "glibc"
@@ -304,14 +304,6 @@ system = "archlinux"
 url = "https://archive.archlinux.org/packages/g/gpgme/gpgme-1.23.2-4-x86_64.pkg.tar.zst"
 sha256 = "e2a1b35695ea4d88fc19e74bc554b7f45f0731e7028e066e4100354586728973"
 signature = "iHUEABYKAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCZiYi2AAKCRBtQr3RFuAGj2U+AQDvXt3MzYy4Fm+Nu1lul/pTYW3pIdGh7SZ2pvkMHNhUXgEA8moKzHQLFtW6g51MSFbUz2pMunFR1Bbv7DzNzgV7GgI="
-
-[[package]]
-name = "guile"
-version = "3.0.10-1"
-system = "archlinux"
-url = "https://archive.archlinux.org/packages/g/guile/guile-3.0.10-1-x86_64.pkg.tar.zst"
-sha256 = "bf4d1b474045a88c7ad97b1ce56e8dd5786e5a10de02a8d33dc8f041edc8d01d"
-signature = "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCZnkshF8UgAAAAAAuAChpc3N1ZXItZnByQG5vdGF0aW9ucy5vcGVucGdwLmZpZnRoaG9yc2VtYW4ubmV0MDVDNzc3NUE5RThCOTc3NDA3RkUwOEU2OUQ0QzVBQTE1NDI2REEwQQAKCRCdTFqhVCbaCruHAQDnjJsHGhq4cae34rHS1z+Hr6yzjVQSxvA6SE9XpredlAD/cstobLSMUsHswxf5df94XkoDPJdJs44uXE/iu9gsgQg="
 
 [[package]]
 name = "hwdata"
@@ -370,12 +362,28 @@ sha256 = "a67ab57d4a9b4caa2e718652c392345cdd9c2496d835ab1d0ff1e78ae4429fde"
 signature = "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCZjJful8UgAAAAAAuAChpc3N1ZXItZnByQG5vdGF0aW9ucy5vcGVucGdwLmZpZnRoaG9yc2VtYW4ubmV0MDVDNzc3NUE5RThCOTc3NDA3RkUwOEU2OUQ0QzVBQTE1NDI2REEwQQAKCRCdTFqhVCbaCpfCAP4sFnTjSEIn5wDbLWGZOivsWT2SWPG6AgofrnUjaK/UMAD9E2u6D7WJbVTYrvDhVUz3WN6k8bVB8ZODyoIF66GWEw0="
 
 [[package]]
+name = "json-c"
+version = "0.17-2"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/j/json-c/json-c-0.17-2-x86_64.pkg.tar.zst"
+sha256 = "0ee6f3e674fa37284edb7bc5be69aade405324e661edeeb101c6be635d029eab"
+signature = "iHUEABYKAB0WIQSDvIiJNRtd67toQW64rAhgDxCM3wUCZoXErQAKCRC4rAhgDxCM34XoAPwMKnwAuDrtCO9vaS+0HJOosrxMtGWqC2xPrmNtS5juWgD+PUCrtolVhKWx+DJWo+7+3Jl902VOZozp21TMjUcUUQg="
+
+[[package]]
 name = "kmod"
 version = "32-1"
 system = "archlinux"
 url = "https://archive.archlinux.org/packages/k/kmod/kmod-32-1-x86_64.pkg.tar.zst"
 sha256 = "9abd6fd54052b48b2bac6e709e25e7be876f68d84949ed4615a3fb8803f2a736"
 signature = "iHUEABYKAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCZegwsQAKCRBtQr3RFuAGj3QXAQDqrsXu36gY3rprKLSh3b3O0VYDQk7UHHSCAveZEHpvxQD/dR6SLukPahSQ8LABJmCFHk4w4d1PgBDRCczcaMYR2QE="
+
+[[package]]
+name = "krb5"
+version = "1.21.3-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/k/krb5/krb5-1.21.3-1-x86_64.pkg.tar.zst"
+sha256 = "7ce8f30ccef0650b964defb7a539c72d5e40fcd288f5f397c1b824d3f4431b2b"
+signature = "iQIzBAABCgAdFiEE4kC1fixGMLp2ji8m/BtUfI2BcsgFAmaJc6UACgkQ/BtUfI2BcsjO0w//R4djAXEL1QcOF/Jh4Ukqy+k+AhvnNSJN5JPhOkvJKc7DqCudBaFcuHdGno6KIAyg42q9PjeIBWxH2kcIVojmGZ+zPvscdX0mjwJAxZ+tBDfa54eOqtnUMGbPDL5QoGeZjfhdQ0hHOFDkpioz8c1hVjdTRvqkC6J5uUGH2SQmD9HfBUFv5O9g/QW+JJI4kXFYnewZewrDOFAccYFjcBjioY1L898+2freJ2JOIh5acf1mtQol/cZhOQevQ/SdZ+BsYZOLp3QFU+IE4Wg+3h2ayEa88A7i/U6ln03GkYNySY1UmqKwrALE9ixW8BSKXoVldtjyiLFH1PHsr0QLmn1IBEt0bis5L059JEdaCv8JKeEElQORUQNLXS6fBV/Oo4oc6mI0SiyOvMPchwkrgvSkh2UKz4AGtpan5EvwRDdaNdhZiCVEDWLIZ6sm0sXRIoJzrB4SsCux9eZnma6Yls47PjgR75ZFbNCr/CHHpZMHyL7mjb8fpZl12mXRcRAMo+3laZsJxUUOymtf3gb/SKQ5rDlYfHxtFaoRvUzKOscUT1d5PQ90KAuD0rbRmUynxBd4FqLAPs7xpcFJtboAsLd1Iax04gAxNtmQQ9F2SujJD+h/LoPwtqu2rU07e9+rcXtKqwYqTxH8TDGpEERsxkUcaLkvsz3sOxIEAUzubYnBn4I="
 
 [[package]]
 name = "libarchive"
@@ -395,11 +403,11 @@ signature = "iHUEABYKAB0WIQRizHP4hOUpV7L92IObeih9mi7GCAUCZgqJbQAKCRCbeih9mi7GCNv
 
 [[package]]
 name = "libbpf"
-version = "1.4.2-1"
+version = "1.4.3-1"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/l/libbpf/libbpf-1.4.2-1-x86_64.pkg.tar.zst"
-sha256 = "70e86fd8bf8e6a0850eed15a580376049d988a28e987afa4c311abd2b1af611c"
-signature = "iQIzBAABCgAdFiEE4kC1fixGMLp2ji8m/BtUfI2BcsgFAmZSc7YACgkQ/BtUfI2Bcsg/HBAAu1v9RTktILD/N34CyIuLCDci6qPeEC3oXDIpZLBnXTwcIwo2Hhhn5n3Sz+k/Tbb6gRMIRhsnqwpxANRo38B9QMODyfeM4wKDNusV1cYUtE/9X3g00dHOYwDu//a/eLj7vHnUWTnFT3zebtRqFUtsFCKr1gogppkQzKCuYx7Nhrl/Z/1md7LEQZXxKWt9d4VSjex4noNMu+7ZujWKZFfYjyPyBzX2mDe96VEBT8BGnMzMjHT07Z7094BAHmVBrNmaJYxkNn34zhMAnG03Lxq93RHgnRJ3K7yzx+rRuEwsqg+7w/47nvgq6K0EaB04jQ6HbW/uIAn3sWIYgMZFIeBxeiCn5qQsNH0u7kSy3fivVuKADmVNG7UphHa3CVcSUi+9nSgt7Ug1RM3vsfX6c/+OiJnQoDHl/ITNZTsmMjc+H0jcJf+3zHyLnKObgEDOTehixOHWUnA8I0MgGCWDeXD8AwSyFl1kponCDgFbrVBwWgv5YvS0lvgTnRo65ix2g/XhVCeqLmgb42t5lnA+QSoRmY21CGalMF1JNvzMwhRr0ZTslbr/OUphjumFylhRcH89QX5HD1UZcq/tbECWsenQiVycN/4iKA0tebCQVyfiqC9yf0A0cKgl4G2gyAO1nN0iZ/5k8zBglcmAksi8xzfeLpGCs36wYnC9Z+HzvEV6StA="
+url = "https://archive.archlinux.org/packages/l/libbpf/libbpf-1.4.3-1-x86_64.pkg.tar.zst"
+sha256 = "5c265558f023b70a5bf91a18a8ef91ef997b76937aff1e02899e8a564ba9df43"
+signature = "iQIzBAABCgAdFiEE4kC1fixGMLp2ji8m/BtUfI2BcsgFAmZgmLQACgkQ/BtUfI2BcsiYVw/6A4E4pNMMnrAQpVElsIoe5mgGjKFiZSQiveupLzqETBHfR3tEo+4pSd/K5COOg0OcZbnVf0QQhWgAlHZwszQdbiqTO6QRRvs8D19g2cDB1id0QjetR5Psxiblv97nOwsD0VSERBZ7DIeD+ssZJs+q31P9fF9jlzXYWV6tlBvSCNRc3vS7ShpO/oFm4SriKbJb5/luIPA4vY/JkPN/LUn5kEc/mqynt8yX/xTA1cnF23YNQ9lc2J8ZMYi30guLbFlRjeXgjaPYYxjYZ6A8j3ua/06VFEhjgCno6WUqBt2qKwZzcra57SKoUh7COah18rHQN+4IxGAW6LUPTvaghWiMFA2Be/R1itx72S4AlXym9/7KLs1mrG4YEeCbq5XYfhCec3oie0dfyKmOT61QhrymLlu7EwkDG1neqk+xo595up7m18q3tdiCPRx+AQZd9cxM1+wgjje2ZNSLRrP076AEZenLYADxhhnL5Omr70d7mGZooMjMu7J4AWxfWXmFYZYxhaZ9ywbWnfJJhkdFPuczOZU38Am0lCZpRSSPt3IYxTxzpQt3esSzhXIOTzH67P4ef55TeIqojzhdXcX8mr1J0LJGduG91lfMTb7X2tiEq8XAGmYHEpMt4VnfdG+wyMLCQXzHWAu1CzDcxBNft79rJE9xaKC/9550FsBkERN501Q="
 
 [[package]]
 name = "libcap"
@@ -491,11 +499,11 @@ signature = "iHUEABYKAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCZfdwygAKCRBtQr3RFuAGj3a
 
 [[package]]
 name = "libmpc"
-version = "1.3.1-1"
+version = "1.3.1-2"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/l/libmpc/libmpc-1.3.1-1-x86_64.pkg.tar.zst"
-sha256 = "a83324a476cae86887aa3e3811b2e72c31471a81be0254e379c244e2df531c1b"
-signature = "iQEzBAABCAAdFiEEFRnVq6Zb9vwrc8dWek52CV2KUuQFAmOfE/EACgkQek52CV2KUuRNEwf6AkQRJ6MKo3+8qZ5DoL1AUfEbRy332+0DbmhqVAZAVR6SDYwr8yTYc5L9zWtRYA++Nh0zah4P6o3XXJISOfLLpQHGPI1jZ/1IGTJlCt0yo+KU891YfQQO95TCAa77oT9Njkxr6imF0vP5kR3PA5sEvqD0iCu69s0TQu2uzsVqigNmbWU3LVv47BrF1T+C31Oa6cRWmjDUtn2ls/jYn+BPvuCO9TyH/3d2lQ1CCM+H1cCDcxzBSmaYSVQUbM6x8YAdFKDZKEbwuiCGTwKIV5ZRar4UiiBdeuJzF0vSy51VdcZpvf30HU8VuJ2Q+mv5OfyHjt/HBCkEyn1b+XufIqb0Xg=="
+url = "https://archive.archlinux.org/packages/l/libmpc/libmpc-1.3.1-2-x86_64.pkg.tar.zst"
+sha256 = "10554706eb15ed2186fbd55fd5db8fa5919788ac9a75d26c0b9ef5bdfca9d470"
+signature = "iQEzBAABCAAdFiEEFRnVq6Zb9vwrc8dWek52CV2KUuQFAmaHCZwACgkQek52CV2KUuRjbAf/TmL9cCMXYTGsNmR2om6kT7XjczfZoFR9AM0FSTUNy5AuNZNUUCfm6ie6F4rFwHc3nETOSojScOZauZlcNiLrVriHYYFSZ8EhKiCJCo68a7KTbceBNoBuT6AEIpGMpIMti/cvWhu8VXl5JIRo8LNPBzDih05aCDUJ2nayKPYNHalDayu87sDXzJYXuzC8KD7XmUa7Kirn0ZpA4VZXc8CUjYYvn0wvRwLKQP4WMpszxmblQWjMVbQxh7dwC+gPtqIANVjoGKMRfr6QpT03XXIEaTBKbMsxeYFvwn+y2JN30t6oFI6LJADZ22VwimEzu06u+x9c+3+pr4k7Py43OCOGmg=="
 
 [[package]]
 name = "libnetfilter_conntrack"
@@ -536,6 +544,14 @@ system = "archlinux"
 url = "https://archive.archlinux.org/packages/l/libnsl/libnsl-2.0.1-1-x86_64.pkg.tar.zst"
 sha256 = "2d9c86e58b6b59e0e3b7dc284d3dc8af6a671f81d13babf076dce6d43de02c52"
 signature = "iHUEABYKAB0WIQRizHP4hOUpV7L92IObeih9mi7GCAUCZSl8fAAKCRCbeih9mi7GCFsgAQCxeFyBcxhdhaDknYrn42Nnkm2P6CPMwqE7VGIbDQ1p2QD9EJK2Tyxncxt9jC+dNMC71fKzYavZvV3SVcp3M8J2VA0="
+
+[[package]]
+name = "libp11-kit"
+version = "0.25.5-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/l/libp11-kit/libp11-kit-0.25.5-1-x86_64.pkg.tar.zst"
+sha256 = "e3e16d93bda4890e19bf480d84f3b3c65c924b78287a3cc3da879721afc3c7a4"
+signature = "iHUEABYKAB0WIQSDvIiJNRtd67toQW64rAhgDxCM3wUCZob0iAAKCRC4rAhgDxCM34fNAQD99QMcqk78I4YJoOMvUYSWP5bp0NsB+zKALcHUAEjpMgEA4RSevlMjgPl0TEoMs/Pej3B8BkEfkxiDc3VMQ/7fxQY="
 
 [[package]]
 name = "libpsl"
@@ -603,11 +619,11 @@ signature = "iQEzBAABCgAdFiEErcih/MFeAdRTEEGelGV6sg8qCSsFAmX2sjsACgkQlGV6sg8qCSv
 
 [[package]]
 name = "libxml2"
-version = "2.13.1-1"
+version = "2.13.2-1"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/l/libxml2/libxml2-2.13.1-1-x86_64.pkg.tar.zst"
-sha256 = "3180fea4f0f9812f5da7408b06dff9ecaa7b53ee158e41d50323a24dab1d6279"
-signature = "iHUEABYKAB0WIQSDvIiJNRtd67toQW64rAhgDxCM3wUCZnLNaQAKCRC4rAhgDxCM31TIAP40xOqm5WBfm7ZV4io0bxTAAINGl8Pl5hZA9E0D+zY0+QD/eUWjNIusw7Ol9slq2KCduSOPJ22AJnZwNvhG4XJdXwA="
+url = "https://archive.archlinux.org/packages/l/libxml2/libxml2-2.13.2-1-x86_64.pkg.tar.zst"
+sha256 = "55d1e6e1b5241b83702a1e6252929c96782031cf2c4573ff2501aa4e51038394"
+signature = "iHUEABYKAB0WIQSDvIiJNRtd67toQW64rAhgDxCM3wUCZob0bAAKCRC4rAhgDxCM35taAQDEeCMlCAFLdli7Q2mqUXQBuhL9+fPlYZcGVwaP2kliEAD/X8ZpwxfcGzZdMhgsEUDK75GIzGdWu+deoJKqe7BvRQU="
 
 [[package]]
 name = "licenses"
@@ -626,20 +642,20 @@ sha256 = "90a7b061db393d9a6f68244f8772053f42d6cce586c561200d2586d4d662e504"
 signature = "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCZjoV/l8UgAAAAAAuAChpc3N1ZXItZnByQG5vdGF0aW9ucy5vcGVucGdwLmZpZnRoaG9yc2VtYW4ubmV0MDVDNzc3NUE5RThCOTc3NDA3RkUwOEU2OUQ0QzVBQTE1NDI2REEwQQAKCRCdTFqhVCbaCkbGAQDgE3AKw3Q01iehBZZsnkeeJItviKl5ymy9TKMrSeReXAD/QkZ9wK4v8R09cvnQPHfwnWV8Myhey1EIiDXnaKhp5Qw="
 
 [[package]]
+name = "lmdb"
+version = "0.9.32-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/l/lmdb/lmdb-0.9.32-1-x86_64.pkg.tar.zst"
+sha256 = "474c654b589b25f80b6bed806b6f5b79ff88f2052d9a54848299ef75a23e3dd5"
+signature = "iQIzBAABCAAdFiEEtZcfLFwQqaCMYAMPeGxj8zDXy5IFAmXLraQACgkQeGxj8zDXy5KzBQ//ainnkpc4j/YWOqY5bYu8BcIIrjk8dgEu4zV3w3QVQflJ160/x1vZPdcCsI5Ur3v9+dQvBYWgNfkSIrMNay+JeAkYpQ9a1MCaOlXoSmHmLUiyzVh9zNy5bY8yDDPNFUJf2oEyAKHvUFR7Fs0qxonqfilKKGehkJR1eSbPU1ZmDOcw5sjCHnZ8GUv8+rwoF4TABJnlvAaZ73YKdkmS3IQ+XQI98sv0rKbyLAM0s/ErBeI2WAx0FE9p19uyB5G8GRokFZt96zIqmHNUpCXbWeHmAIVcvDk2s6StHqywS5kEATLkHxLRaPQY2axVeluL/OGeHRyevDW/mYdwJgNa7Nlawgnq5PsyyLAdY310gYtwyx8HAMrhkEGOH1udno2sqmZ4vDpUjeSS1NPZ+4gq2/+Nk8KDlLj96IQHYnhV8PspcSG0Q9WCBWbVQ12r4K2+8XIO9gI8hg5/7kSevNz8Vcamcy84ezJpHZ88m+LpNLDmVL2BiMN6qMhMf+Ka3KeRyUgkDo9nZf9s/JjehkjGiKZJs74YnNzgPnKfeu53l2xyQw/QxG9kB0dOAGsiRFz/VZhuSyWK3cc60lvaMuDFjzSdMCuqAHzZrc0iVD412FZAtgE8Ek8Vi7XXhokwnXOT6Y3rSA5lpJhUPgI56Xfl5lXxD3opFN2shTaCe95KEsjcoag="
+
+[[package]]
 name = "lz4"
 version = "1:1.9.4-3"
 system = "archlinux"
 url = "https://archive.archlinux.org/packages/l/lz4/lz4-1:1.9.4-3-x86_64.pkg.tar.zst"
 sha256 = "aa92898d7ed44ce1929c1d59bd07c45afcaa7226fedb1772e0fd7672de499222"
 signature = "iHUEABYKAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCZfdwFAAKCRBtQr3RFuAGjxHcAQCUFpgmktTvH5FRfhqmUjciCqHPOPPw10/CD/X9aYEKxwEA4raaSN3gOj/ISaJmHb9NIwih+pxw132G5f7g+9F/mQU="
-
-[[package]]
-name = "make"
-version = "4.4.1-2"
-system = "archlinux"
-url = "https://archive.archlinux.org/packages/m/make/make-4.4.1-2-x86_64.pkg.tar.zst"
-sha256 = "7c1bc0d882f7c8d1bcb305eb7efaabc19ed6afa5a9a443575fa0d5ed57985535"
-signature = "iHUEABYKAB0WIQSZH24/B2XPYpWIhYYTmwnaW/DTOAUCZBT0lQAKCRATmwnaW/DTOKwJAP9/kfT3rO0NhbD8wuI6ajzjyKtrl4SfuU0yu/PKByXQOgD/aYSvsyXylJhCadU2smO4LbP2Vj9fnIvEwPvbXbesVQ0="
 
 [[package]]
 name = "mpfr"
@@ -651,11 +667,19 @@ signature = "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCZjqbXF8UgAAAAAAuAChpc3N
 
 [[package]]
 name = "musl"
-version = "1.2.5-1"
+version = "1.2.5-2"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/m/musl/musl-1.2.5-1-x86_64.pkg.tar.zst"
-sha256 = "914fc5796209750652303e830c6ddc2478ffa27261801592ac49f64a1456bac6"
-signature = "iQJLBAABCAA1FiEEiee5MxxK59f699MFwTIpOVS75K0FAmXjEw8XHHNwdXB5a2luQGFyY2hsaW51eC5vcmcACgkQwTIpOVS75K1yCg/+KLpAazqnCdR0qY6xNJM/v21L8B5Jl6+KIQCZ9NCTn0/33gQBCvMGghcx1WblzEslI6zjq2xHVzO7o2X2c3Vkl/XgsomY/DeXzK/GGVm+4yeyVe/M5CALqnzkHZiqEQvNkUW+7IKMHxmVWeXDhSWEv0k2SwEkl8K+Ge+BK1wdhXoj767YZXuf+09o8e6a4T1tLjauopBE7/7fXYD7/G0/UJueVQrFv72ouujL+Cazpv7vZfJYT8WjmhgPfHxBGKKNYzb9VICSw1jw6O1KAOd6b9j6kA+LkBYMkzFzCrVB3T5QXFSntUv2lBFvX03/E+1uTv3aAoBDFvaE1nveXODl35Tvh8/hyUdiKYjpbAY4nlrgjjgZF7ydL6cmv0KkhGNa6sVLANScKBRGjeGoHVWEIRLIeFG7KUymUPE6Yndak7Y6INr1lDH7gEqiWcVEd+27GstCk4g+dijrIV3PNer3JzJzBNYVxRXaIeIpSgn61tsca0KrmS3kr4j6fwX3K4ILBL4HcCsSCnk2HUFDtBlMiYGACsB/ue10MVmDZF1LDs8jxyrYLviCgR7e6iENAmkbd0UhQniC0vG2HiAJA2K6IYk9btw4ItUtFUdm7OnIcJlIt6LCaa9V3IJ87uZIPNlWCGZxPLPMyByCAGSOOvmYO5U248Sknqs4FFDGKVsrHAo="
+url = "https://archive.archlinux.org/packages/m/musl/musl-1.2.5-2-x86_64.pkg.tar.zst"
+sha256 = "146b60543069d4eb92fd9086ffd6f442ee0a1f41f724445adc29af80693ce2da"
+signature = "iQJLBAABCAA1FiEEiee5MxxK59f699MFwTIpOVS75K0FAmaUdzsXHHNwdXB5a2luQGFyY2hsaW51eC5vcmcACgkQwTIpOVS75K2C+g//ddIjb7CKai01nuuzLd9hZQBP51iBe+lYdhv5lxlKaSzQZXHVUGXDAZdb7TaV9pbzdGPE+l5V2ZngivXdR5twUDWOQzvorXdxLgX7trBTghLDTBIKu6jPtrH2bNWrL8A908RumQVeWsOxUcompgAsRpQ4DhZkzk8325k9et0Nv1oQic96B5G1WefE85IYc2PDJeRhfyfnZmQ15aoVhohyhF0XSudlJSc/hqMZePW8tmyYz4ltvgOs4EF3smNwOaZVOew+w/5vOCYaSre5MFwHiilvYJaWhCji10m0MrBzLhRx0ZfRlBwTGbsToRbmczuwMXoYIiJsI2OiXsZD5/X9T5yPjl7pWP7uLaNTXCcbfrCZIWMVBXYQFxnWhUbKFZu8E7eXU2z75GukkC7GjR+VKw+SFH06Xdq73JltIXURRKe03uigC8ciME1xHOMv5kc1pQukQC/hTaR4GPF32pOX27CPQkNQ0dhRi1Cgyt47V+3GncI+mhlY3gJsCv31+Z0kM+WornVJYFSQnO0/frFPJaZUt0ONO7lHU2UMTe2tHm+zFHuHh6xOGaMjdRslrzq0Pby0xMb6nT0HsT1VXfSW30rywN1UPLd3TxAXGkG3SS8szftrLrmK6NAsK5tWfd5H2tiwSibYNnYYYVB720LKBl7bgpGFicdROohXJKqXsvA="
+
+[[package]]
+name = "musl-aarch64"
+version = "1.2.5-2"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/m/musl-aarch64/musl-aarch64-1.2.5-2-x86_64.pkg.tar.zst"
+sha256 = "a127125a8b889341e8ee1d9a68b75b7afbc7af9a13e0203c460b5bf266084df3"
+signature = "iQJLBAABCAA1FiEEiee5MxxK59f699MFwTIpOVS75K0FAmaUdzwXHHNwdXB5a2luQGFyY2hsaW51eC5vcmcACgkQwTIpOVS75K3i7xAAgtV4szRrzrfudev6aAAIeGUMMmYRuzSjicbS8+2jMdJUTeWkHRpEWkA/f+T29ki9OlJAHzotThWREgetwkoXrovUfugb0MNY++u4Oo3N2Z72AS1ndweWy/0ewz/0sOuVn6NNfTek8BhXa9lzhPLbd+JLRHXqlt4gz6tS8ax9aiXuUqKIqjo00HTfwiMYyaUbRx83eJL/0549A2Rq72Ju7vDIBnRe2Bf5brYkRBluVbOKgEEEDJ63pwzzw2K694YJyIzGmeLf5ZKG2dVyQZ9RoR08bwMXGKt7qInijgbDozNp3GOdvVL/v4wMByc1TjqazycJmSgKqFALgLxBsxm9LjT+j2OCpz5imS4I1OecuJSO5bTHZNhkgE9rqsGdjVNUjLSgvQem/k8OdIWrnF5W7bfCZEI7EUI5qxAG3uh6jCG/LEJkjIuR7IN17sDtl50DcPpN/Sr4wcETXfoz1NNB3b8ZwBITkADBnDu+lmG2+x7pPXicZSVOPN8i1IYnq8r11Aw1GxOCXQZsGfsJgByjWYs5iD1Y/8JLlsw7aagwjZoh2bMGadlA+tzY83+2OP2Nq4Vrhwum96ec7vUoe3kKADJ0751IHW3+anqglMivyOXmngBObAcoWb/Q1HrTMTQy6SGemdM614Yw/h+tJizeOvugkqbX3gny7grDrIgmjRY="
 
 [[package]]
 name = "ncurses"
@@ -688,6 +712,14 @@ system = "archlinux"
 url = "https://archive.archlinux.org/packages/o/openssl/openssl-3.3.1-1-x86_64.pkg.tar.zst"
 sha256 = "3d0540fb0d4196c9d8bc369c7d2faa8800a37d4f57e4b3cb418dd438fd3c59dc"
 signature = "iHUEABYKAB0WIQQ+gMoai4n2nLpX2Yp2pe+QVESaXAUCZl9thAAKCRB2pe+QVESaXPZ8AQDIUORLQtyVcPznVihzQAv8blUov4Hed21VTKr3xyrI2AD/Vsb6QEV/ITwbEk9hKgi4rjruYyMaDUSliBd9XQL7PgA="
+
+[[package]]
+name = "p11-kit"
+version = "0.25.5-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/p/p11-kit/p11-kit-0.25.5-1-x86_64.pkg.tar.zst"
+sha256 = "fddfcb0eede8619d1185f9834426c27db68407fa5fb2eabd4cba360116fa536b"
+signature = "iHUEABYKAB0WIQSDvIiJNRtd67toQW64rAhgDxCM3wUCZob0hwAKCRC4rAhgDxCM3/AIAQDWuPLCUdBREcAK7E0Yjz7ZhXdoF1yd4u4PcMuswFhNYQD9GmxAlIR6t0FGFkqGzr3nzImV0pb0v5t8Sb0OPLrBsQc="
 
 [[package]]
 name = "pacman"
@@ -832,14 +864,6 @@ system = "archlinux"
 url = "https://archive.archlinux.org/packages/u/util-linux-libs/util-linux-libs-2.40.2-1-x86_64.pkg.tar.zst"
 sha256 = "f2b27ad8987bd146aa9431aec36cbd73b0a820c4996b91cac15afcebd96ea399"
 signature = "iHUEABYKAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCZoZctQAKCRBtQr3RFuAGj94rAP0ZLhpNPjBwnpon0hlXT6gKrRAxiD5BdsDCPjSTA5B2rgEAhjBvxUGHDD2X9meZ0uE8ilKpjjmyQtBWHASwab5VBwo="
-
-[[package]]
-name = "wget"
-version = "1.24.5-3"
-system = "archlinux"
-url = "https://archive.archlinux.org/packages/w/wget/wget-1.24.5-3-x86_64.pkg.tar.zst"
-sha256 = "fd928001f09cf506f5db8614501d49abea2c18e6546140db9bac450cf0e60b80"
-signature = "iHUEABYKAB0WIQRUwf0nM2HqUUojd5Pylr3lA2jGzgUCZnw1DgAKCRDylr3lA2jGzsANAP4zcY+oGqNvPyR4AVVGPESLblBvPrvq2PuUAh5edlgPRAD9EaxkTGK1BxQh5ssBmf3+fvYDnbJjEhy1ZCBWbtriGwU="
 
 [[package]]
 name = "xz"

--- a/pkgs/sh4d0wup/repro-env.toml
+++ b/pkgs/sh4d0wup/repro-env.toml
@@ -7,9 +7,8 @@ dependencies = [
     "aarch64-linux-gnu-gcc",
     "cargo-deb",
     "gcc",
-    "make",
     "musl",
+    "musl-aarch64",
     "perl",
     "rustup",
-    "wget",
 ]

--- a/pkgs/sn0int/build.toml
+++ b/pkgs/sn0int/build.toml
@@ -18,22 +18,6 @@ set -e
 # 2024-01-01
 export SOURCE_DATE_EPOCH=1704067200
 
-wget https://www.musl-libc.org/releases/musl-1.2.5.tar.gz
-echo 'a9a118bbe84d8764da0ea0d28b3ab3fae8477fc7e4085d90102b8596fc7c75e4  musl-1.2.5.tar.gz' | sha256sum -c -
-tar xf musl-1.2.5.tar.gz
-
-pushd musl-1.2.5/
-CROSS_COMPILE="aarch64-linux-gnu-" \
-./configure --prefix=/usr/aarch64-linux-musl/lib/musl \
-  --exec-prefix=/usr/aarch64-linux-musl \
-  --enable-wrapper=all \
-  --target="aarch64-linux-musl" \
-  CFLAGS="-ffat-lto-objects"
-make
-make DESTDIR="/" install
-mv -v /lib/ld-musl-aarch64.so* /usr/aarch64-linux-musl/lib/
-popd
-
 mkdir -vp ~/.cargo
 printf '[target.aarch64-unknown-linux-musl]\\nlinker = "/usr/aarch64-linux-musl/bin/musl-gcc"\\n' > ~/.cargo/config.toml
 

--- a/pkgs/sn0int/repro-env.lock
+++ b/pkgs/sn0int/repro-env.lock
@@ -43,11 +43,11 @@ signature = "iHUEABYKAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCZbDRHwAKCRBtQr3RFuAGj1S
 
 [[package]]
 name = "archlinux-keyring"
-version = "20240609-1"
+version = "20240709-1"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/a/archlinux-keyring/archlinux-keyring-20240609-1-any.pkg.tar.zst"
-sha256 = "1498cbf8f9511a7c4f52b40b392bf8779e9543195f2a0a95a9dcda7b49dd0f9f"
-signature = "iHUEABYKAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCZmYV4QAKCRBtQr3RFuAGj5TKAQC4YJtPS54Mbb1HpkGBtt/rnHcZJwCTGkZ5oyPcWqen+QD+ICYfcLg4P1+sj+hMfPmDXQf4aKBLDrFkKKvSvCgy6wY="
+url = "https://archive.archlinux.org/packages/a/archlinux-keyring/archlinux-keyring-20240709-1-any.pkg.tar.zst"
+sha256 = "a6f573fc97fc21b55504a4d75d010257792847a5b87f19edff4ffb662f6f53a2"
+signature = "iHUEABYKAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCZo2s1wAKCRBtQr3RFuAGj9MSAQDCI730nuxWZ70VM9xGZZZDyLwb6LdAN+fbUdkNzaE3wAEAsNqHKFnUKRnBXwGOv3j8VrP+XaGD0P2QJAEocEeWiQM="
 
 [[package]]
 name = "attr"
@@ -123,11 +123,11 @@ signature = "iHUEABYKAB0WIQSDvIiJNRtd67toQW64rAhgDxCM3wUCZnHT6wAKCRC4rAhgDxCM32T
 
 [[package]]
 name = "cargo-deb"
-version = "2.3.0-1"
+version = "2.4.0-1"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/c/cargo-deb/cargo-deb-2.3.0-1-x86_64.pkg.tar.zst"
-sha256 = "537a26f5a9b057689f42b7b37cb903c95ac0b982908e237e20a652c577246fbe"
-signature = "iQIzBAABCAAdFiEEFl4P98SMIm4ew2On+DQkgks+S5AFAmZrA44ACgkQ+DQkgks+S5AOeA/9FVP0P9inRSQTYfG9VphaTxS2MIB6+HPOR5AaV5z/M0fSO8ux92vtbQcWMKrccttwk5rL6evxJAkMzYSXRJ9Gdua1yYCO8yJ+kr1rffvG/SafCBsnkvoyM+2CAgSwnBWDkWUm7MljyyyNMswcj3WIIrikdJVAKzanzSONlCeioF+zZM1ODZe1N4GVA3A9JlbDuAFVJkzlpqPkLYLr6iAPYyLjHpbPfOhnyDcTJDoDmH8kUWGXPt2W2J7OIIRtrYmUpevG0AS5X6+D37dxmi3qtxeZPnskUiSZ6kbdHLhdAQnte8XkfRUYZ+LtU/YBzjbC5QiKj/9RE/2Rp7NkcdJk/MreolKhQqbVYFNzKYeJamJaNj63fSGKL3X83NYY62w0tS89qRv1AklbLU84Ilutw3YaBTmdlyVSvzYSmfqMie7w3brwQAVRGysyvdMh3K9gMoGZuXpDXE08PQwWtY1h9Q1MmSx8bKWg60VEyLhS3SK5/PjvuS3/6YGgQa1Wxy6lIqSY1wKRg6WlyU+RM8S9Dl5Gtlr6jYAJvkFKgEy1It7UdR5vhPw+DQfb9LIzJnON644qteOhCKJQIEH/JGGH820V3Gq+20jPXjYb7oQoqimnB52yJI53FY/jdX3OsCpE7fojqpBWeLLZ2KKBcSsqwBO2hpNojnuOtCJZyw23BF4="
+url = "https://archive.archlinux.org/packages/c/cargo-deb/cargo-deb-2.4.0-1-x86_64.pkg.tar.zst"
+sha256 = "6b0a76d71961c376129b79d81d318ce9cb401dd21796bf642b8950092cc559c7"
+signature = "iQIzBAABCAAdFiEEM+u4qOHFZTZFsSMqRaZQ4mOMU20FAmaLye4ACgkQRaZQ4mOMU21+Sg//SneMbZek0hl1LONnsp1BkJ4OAxHD8KZ7ZUVgNqoKxFo7Y/vyEnY1QKo6BLTikH6MheSvXhWpdLpNnqXEJj8QA46HNCjaU8rugq0EPJ3meB8I+7qnlelCTwNWIB12UVvOjCm1mR5ux96W/BZjN3Ur7jfQlEHjYsM6ToL+tq2HitkNdQvKO0L6dyQC3FbfqZsi37nBdv7gQKh5IjV0beZ6RReEyEuzBC1Uio3HN3IuStZMSmxiXgpITjwLkHHztNFub0hhQO69065l4CFueqci0aNtkp5xoXF8Qflwui9f0MdxUc8m/5sdf95NTDFWnyh8MnUs3/qqPY6FyQ1uaaf8TxGspO0AQYzkLthe50wEd9aChCinU3x8/17p909u70fGVU6eBqMPugXwzrrHGOJ8JLviUQuGC8kOWvtuEt9oRHnwetWCMVWNcUVHCIl4GG5DBzHPeNP9li8TSoHW8RV7EbxVEtzSnfXxWh3tBRfau0ugxgVlmC7Dn+/wt5PxAXIGZP7MqmRyzBJYVG7vWBHdPFzUEJD0n0dL8IwOWOvbhG4cZ6yfiGHt3yzgbrIMUsDsqdeS8B7EteyAWmNaAkTiuiV58qsy6IfE86b//hfq/NlpKRzuDx+vVlJAYoEfZBblw6k3txlDb1YHc6NQ4PeVFTnQKNDb+WFMSoai4OPxEjg="
 
 [[package]]
 name = "coreutils"
@@ -218,14 +218,6 @@ sha256 = "f7d9994d70d5bac0e99a66508673abba271d1b0b0598e001b7a677d182663500"
 signature = "iQEzBAABCAAdFiEEW34/txt/EDKaHAOrdx32Yn7faB8FAmZbgL0ACgkQdx32Yn7faB8F/ggAt6EqPhQ7KsinXsEEJhE+ammbeflgv4eKpmhP6wlfnb0Cg3TerAKdEbXUdR3rpcztE2f/zLJ+Fs9dYV5DOqcMV5cpLWD0NYjo/SmiZMVjM1/ZWskbnhyMAsfDQwUXXZYruMiOGdMpJFu8sqKBkQqrd4cOkn3AF2r2wXW+PF2r2yb0K9mv6YW285RIEo7aphVsI0LZgKbrksDeMbWQF3U3A1WHrVX1rDXPB0CSnxkIaEm3erzaFj8dhrFd4/7k7iIUjLFP2Ev6HhBjr0CA7V62LtJ9EOyGtYCY7SB4SKL8EWdWJK513jpVe6gu/5M5A3H0zmA8w5E83zW/Z5nbZvnFkQ=="
 
 [[package]]
-name = "gc"
-version = "8.2.6-1"
-system = "archlinux"
-url = "https://archive.archlinux.org/packages/g/gc/gc-8.2.6-1-x86_64.pkg.tar.zst"
-sha256 = "6210a1e7e00d3162f175f9ab318a3da928495210b1ea411dcb66bf5e1f382daf"
-signature = "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCZb9oiF8UgAAAAAAuAChpc3N1ZXItZnByQG5vdGF0aW9ucy5vcGVucGdwLmZpZnRoaG9yc2VtYW4ubmV0MDVDNzc3NUE5RThCOTc3NDA3RkUwOEU2OUQ0QzVBQTE1NDI2REEwQQAKCRCdTFqhVCbaCmQdAP0fleaFihboUqrAdlMxvO5OUJiXXxLtimhQj2e3rD9L3gEA0YzMCzi4GS6GlV1pa/hZ68bPL2gYz2goni9/aLXhMwY="
-
-[[package]]
 name = "gcc"
 version = "14.1.1+r58+gfc9fb69ad62-1"
 system = "archlinux"
@@ -242,6 +234,14 @@ sha256 = "7605cb1ab1830dbdd564591d33adeec78ce79c1733bd98f36ba3e81eb9748b78"
 signature = "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCZk3zsF8UgAAAAAAuAChpc3N1ZXItZnByQG5vdGF0aW9ucy5vcGVucGdwLmZpZnRoaG9yc2VtYW4ubmV0MDVDNzc3NUE5RThCOTc3NDA3RkUwOEU2OUQ0QzVBQTE1NDI2REEwQQAKCRCdTFqhVCbaCugeAQDgJyrXuoZnSZFU/gz5rGccNOuGSgOvfYX2YTY1drfb/AEA4pmZIr4MJC/1XQF5AmrhxTX491TtbJgxdstI+1KysAs="
 
 [[package]]
+name = "gdbm"
+version = "1.24-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/g/gdbm/gdbm-1.24-1-x86_64.pkg.tar.zst"
+sha256 = "2712f2747f887ff19ad4151143e506e80254a0a0db0e8b968adb6634da7800ab"
+signature = "iHUEABYKAB0WIQRizHP4hOUpV7L92IObeih9mi7GCAUCZoa2fgAKCRCbeih9mi7GCKXhAQDIaNqIfZ2hIa29L7FE1axM7Ui45KQxU/XOCC2cnzisvAD/aecNLEqMxSnE/FsOhZdi0dAHLAuOjVRSpF6IbtF1NgM="
+
+[[package]]
 name = "gettext"
 version = "0.22.5-1"
 system = "archlinux"
@@ -251,11 +251,11 @@ signature = "iQEzBAABCAAdFiEEW34/txt/EDKaHAOrdx32Yn7faB8FAmY7WIYACgkQdx32Yn7faB9
 
 [[package]]
 name = "glib2"
-version = "2.80.3-2"
+version = "2.80.4-1"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/g/glib2/glib2-2.80.3-2-x86_64.pkg.tar.zst"
-sha256 = "5097ae4a68ce205c4ffa370d5d9ba3e4ad9afb97d61e3d3f61d9b944813e7ad4"
-signature = "iHUEABYKAB0WIQSDvIiJNRtd67toQW64rAhgDxCM3wUCZmjHogAKCRC4rAhgDxCM30ONAQDMZoZSkJDOZDPD9PMLvhbK1VJxJp8VRgdxG1OILR9kfAD/evaIoFqw0LCQaTkKdSavJURgzmjh9g+LJ4FM7OnIzwA="
+url = "https://archive.archlinux.org/packages/g/glib2/glib2-2.80.4-1-x86_64.pkg.tar.zst"
+sha256 = "047121788777ae88726ee10525fba0ab05cc495cdb336a45bea6cdd0793c8d06"
+signature = "iHUEABYKAB0WIQSDvIiJNRtd67toQW64rAhgDxCM3wUCZoxhigAKCRC4rAhgDxCM37jmAQCMi355gHS4atKFg2Zr5R5hElvjlTp2vx7s2MniqS4usAD+KrBXRueBCElmnuplANh2d71qDwjAG7FFueZk8bp61wA="
 
 [[package]]
 name = "glibc"
@@ -296,14 +296,6 @@ system = "archlinux"
 url = "https://archive.archlinux.org/packages/g/gpgme/gpgme-1.23.2-4-x86_64.pkg.tar.zst"
 sha256 = "e2a1b35695ea4d88fc19e74bc554b7f45f0731e7028e066e4100354586728973"
 signature = "iHUEABYKAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCZiYi2AAKCRBtQr3RFuAGj2U+AQDvXt3MzYy4Fm+Nu1lul/pTYW3pIdGh7SZ2pvkMHNhUXgEA8moKzHQLFtW6g51MSFbUz2pMunFR1Bbv7DzNzgV7GgI="
-
-[[package]]
-name = "guile"
-version = "3.0.10-1"
-system = "archlinux"
-url = "https://archive.archlinux.org/packages/g/guile/guile-3.0.10-1-x86_64.pkg.tar.zst"
-sha256 = "bf4d1b474045a88c7ad97b1ce56e8dd5786e5a10de02a8d33dc8f041edc8d01d"
-signature = "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCZnkshF8UgAAAAAAuAChpc3N1ZXItZnByQG5vdGF0aW9ucy5vcGVucGdwLmZpZnRoaG9yc2VtYW4ubmV0MDVDNzc3NUE5RThCOTc3NDA3RkUwOEU2OUQ0QzVBQTE1NDI2REEwQQAKCRCdTFqhVCbaCruHAQDnjJsHGhq4cae34rHS1z+Hr6yzjVQSxvA6SE9XpredlAD/cstobLSMUsHswxf5df94XkoDPJdJs44uXE/iu9gsgQg="
 
 [[package]]
 name = "hwdata"
@@ -362,12 +354,28 @@ sha256 = "a67ab57d4a9b4caa2e718652c392345cdd9c2496d835ab1d0ff1e78ae4429fde"
 signature = "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCZjJful8UgAAAAAAuAChpc3N1ZXItZnByQG5vdGF0aW9ucy5vcGVucGdwLmZpZnRoaG9yc2VtYW4ubmV0MDVDNzc3NUE5RThCOTc3NDA3RkUwOEU2OUQ0QzVBQTE1NDI2REEwQQAKCRCdTFqhVCbaCpfCAP4sFnTjSEIn5wDbLWGZOivsWT2SWPG6AgofrnUjaK/UMAD9E2u6D7WJbVTYrvDhVUz3WN6k8bVB8ZODyoIF66GWEw0="
 
 [[package]]
+name = "json-c"
+version = "0.17-2"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/j/json-c/json-c-0.17-2-x86_64.pkg.tar.zst"
+sha256 = "0ee6f3e674fa37284edb7bc5be69aade405324e661edeeb101c6be635d029eab"
+signature = "iHUEABYKAB0WIQSDvIiJNRtd67toQW64rAhgDxCM3wUCZoXErQAKCRC4rAhgDxCM34XoAPwMKnwAuDrtCO9vaS+0HJOosrxMtGWqC2xPrmNtS5juWgD+PUCrtolVhKWx+DJWo+7+3Jl902VOZozp21TMjUcUUQg="
+
+[[package]]
 name = "kmod"
 version = "32-1"
 system = "archlinux"
 url = "https://archive.archlinux.org/packages/k/kmod/kmod-32-1-x86_64.pkg.tar.zst"
 sha256 = "9abd6fd54052b48b2bac6e709e25e7be876f68d84949ed4615a3fb8803f2a736"
 signature = "iHUEABYKAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCZegwsQAKCRBtQr3RFuAGj3QXAQDqrsXu36gY3rprKLSh3b3O0VYDQk7UHHSCAveZEHpvxQD/dR6SLukPahSQ8LABJmCFHk4w4d1PgBDRCczcaMYR2QE="
+
+[[package]]
+name = "krb5"
+version = "1.21.3-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/k/krb5/krb5-1.21.3-1-x86_64.pkg.tar.zst"
+sha256 = "7ce8f30ccef0650b964defb7a539c72d5e40fcd288f5f397c1b824d3f4431b2b"
+signature = "iQIzBAABCgAdFiEE4kC1fixGMLp2ji8m/BtUfI2BcsgFAmaJc6UACgkQ/BtUfI2BcsjO0w//R4djAXEL1QcOF/Jh4Ukqy+k+AhvnNSJN5JPhOkvJKc7DqCudBaFcuHdGno6KIAyg42q9PjeIBWxH2kcIVojmGZ+zPvscdX0mjwJAxZ+tBDfa54eOqtnUMGbPDL5QoGeZjfhdQ0hHOFDkpioz8c1hVjdTRvqkC6J5uUGH2SQmD9HfBUFv5O9g/QW+JJI4kXFYnewZewrDOFAccYFjcBjioY1L898+2freJ2JOIh5acf1mtQol/cZhOQevQ/SdZ+BsYZOLp3QFU+IE4Wg+3h2ayEa88A7i/U6ln03GkYNySY1UmqKwrALE9ixW8BSKXoVldtjyiLFH1PHsr0QLmn1IBEt0bis5L059JEdaCv8JKeEElQORUQNLXS6fBV/Oo4oc6mI0SiyOvMPchwkrgvSkh2UKz4AGtpan5EvwRDdaNdhZiCVEDWLIZ6sm0sXRIoJzrB4SsCux9eZnma6Yls47PjgR75ZFbNCr/CHHpZMHyL7mjb8fpZl12mXRcRAMo+3laZsJxUUOymtf3gb/SKQ5rDlYfHxtFaoRvUzKOscUT1d5PQ90KAuD0rbRmUynxBd4FqLAPs7xpcFJtboAsLd1Iax04gAxNtmQQ9F2SujJD+h/LoPwtqu2rU07e9+rcXtKqwYqTxH8TDGpEERsxkUcaLkvsz3sOxIEAUzubYnBn4I="
 
 [[package]]
 name = "libarchive"
@@ -387,11 +395,11 @@ signature = "iHUEABYKAB0WIQRizHP4hOUpV7L92IObeih9mi7GCAUCZgqJbQAKCRCbeih9mi7GCNv
 
 [[package]]
 name = "libbpf"
-version = "1.4.2-1"
+version = "1.4.3-1"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/l/libbpf/libbpf-1.4.2-1-x86_64.pkg.tar.zst"
-sha256 = "70e86fd8bf8e6a0850eed15a580376049d988a28e987afa4c311abd2b1af611c"
-signature = "iQIzBAABCgAdFiEE4kC1fixGMLp2ji8m/BtUfI2BcsgFAmZSc7YACgkQ/BtUfI2Bcsg/HBAAu1v9RTktILD/N34CyIuLCDci6qPeEC3oXDIpZLBnXTwcIwo2Hhhn5n3Sz+k/Tbb6gRMIRhsnqwpxANRo38B9QMODyfeM4wKDNusV1cYUtE/9X3g00dHOYwDu//a/eLj7vHnUWTnFT3zebtRqFUtsFCKr1gogppkQzKCuYx7Nhrl/Z/1md7LEQZXxKWt9d4VSjex4noNMu+7ZujWKZFfYjyPyBzX2mDe96VEBT8BGnMzMjHT07Z7094BAHmVBrNmaJYxkNn34zhMAnG03Lxq93RHgnRJ3K7yzx+rRuEwsqg+7w/47nvgq6K0EaB04jQ6HbW/uIAn3sWIYgMZFIeBxeiCn5qQsNH0u7kSy3fivVuKADmVNG7UphHa3CVcSUi+9nSgt7Ug1RM3vsfX6c/+OiJnQoDHl/ITNZTsmMjc+H0jcJf+3zHyLnKObgEDOTehixOHWUnA8I0MgGCWDeXD8AwSyFl1kponCDgFbrVBwWgv5YvS0lvgTnRo65ix2g/XhVCeqLmgb42t5lnA+QSoRmY21CGalMF1JNvzMwhRr0ZTslbr/OUphjumFylhRcH89QX5HD1UZcq/tbECWsenQiVycN/4iKA0tebCQVyfiqC9yf0A0cKgl4G2gyAO1nN0iZ/5k8zBglcmAksi8xzfeLpGCs36wYnC9Z+HzvEV6StA="
+url = "https://archive.archlinux.org/packages/l/libbpf/libbpf-1.4.3-1-x86_64.pkg.tar.zst"
+sha256 = "5c265558f023b70a5bf91a18a8ef91ef997b76937aff1e02899e8a564ba9df43"
+signature = "iQIzBAABCgAdFiEE4kC1fixGMLp2ji8m/BtUfI2BcsgFAmZgmLQACgkQ/BtUfI2BcsiYVw/6A4E4pNMMnrAQpVElsIoe5mgGjKFiZSQiveupLzqETBHfR3tEo+4pSd/K5COOg0OcZbnVf0QQhWgAlHZwszQdbiqTO6QRRvs8D19g2cDB1id0QjetR5Psxiblv97nOwsD0VSERBZ7DIeD+ssZJs+q31P9fF9jlzXYWV6tlBvSCNRc3vS7ShpO/oFm4SriKbJb5/luIPA4vY/JkPN/LUn5kEc/mqynt8yX/xTA1cnF23YNQ9lc2J8ZMYi30guLbFlRjeXgjaPYYxjYZ6A8j3ua/06VFEhjgCno6WUqBt2qKwZzcra57SKoUh7COah18rHQN+4IxGAW6LUPTvaghWiMFA2Be/R1itx72S4AlXym9/7KLs1mrG4YEeCbq5XYfhCec3oie0dfyKmOT61QhrymLlu7EwkDG1neqk+xo595up7m18q3tdiCPRx+AQZd9cxM1+wgjje2ZNSLRrP076AEZenLYADxhhnL5Omr70d7mGZooMjMu7J4AWxfWXmFYZYxhaZ9ywbWnfJJhkdFPuczOZU38Am0lCZpRSSPt3IYxTxzpQt3esSzhXIOTzH67P4ef55TeIqojzhdXcX8mr1J0LJGduG91lfMTb7X2tiEq8XAGmYHEpMt4VnfdG+wyMLCQXzHWAu1CzDcxBNft79rJE9xaKC/9550FsBkERN501Q="
 
 [[package]]
 name = "libcap"
@@ -483,11 +491,11 @@ signature = "iHUEABYKAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCZfdwygAKCRBtQr3RFuAGj3a
 
 [[package]]
 name = "libmpc"
-version = "1.3.1-1"
+version = "1.3.1-2"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/l/libmpc/libmpc-1.3.1-1-x86_64.pkg.tar.zst"
-sha256 = "a83324a476cae86887aa3e3811b2e72c31471a81be0254e379c244e2df531c1b"
-signature = "iQEzBAABCAAdFiEEFRnVq6Zb9vwrc8dWek52CV2KUuQFAmOfE/EACgkQek52CV2KUuRNEwf6AkQRJ6MKo3+8qZ5DoL1AUfEbRy332+0DbmhqVAZAVR6SDYwr8yTYc5L9zWtRYA++Nh0zah4P6o3XXJISOfLLpQHGPI1jZ/1IGTJlCt0yo+KU891YfQQO95TCAa77oT9Njkxr6imF0vP5kR3PA5sEvqD0iCu69s0TQu2uzsVqigNmbWU3LVv47BrF1T+C31Oa6cRWmjDUtn2ls/jYn+BPvuCO9TyH/3d2lQ1CCM+H1cCDcxzBSmaYSVQUbM6x8YAdFKDZKEbwuiCGTwKIV5ZRar4UiiBdeuJzF0vSy51VdcZpvf30HU8VuJ2Q+mv5OfyHjt/HBCkEyn1b+XufIqb0Xg=="
+url = "https://archive.archlinux.org/packages/l/libmpc/libmpc-1.3.1-2-x86_64.pkg.tar.zst"
+sha256 = "10554706eb15ed2186fbd55fd5db8fa5919788ac9a75d26c0b9ef5bdfca9d470"
+signature = "iQEzBAABCAAdFiEEFRnVq6Zb9vwrc8dWek52CV2KUuQFAmaHCZwACgkQek52CV2KUuRjbAf/TmL9cCMXYTGsNmR2om6kT7XjczfZoFR9AM0FSTUNy5AuNZNUUCfm6ie6F4rFwHc3nETOSojScOZauZlcNiLrVriHYYFSZ8EhKiCJCo68a7KTbceBNoBuT6AEIpGMpIMti/cvWhu8VXl5JIRo8LNPBzDih05aCDUJ2nayKPYNHalDayu87sDXzJYXuzC8KD7XmUa7Kirn0ZpA4VZXc8CUjYYvn0wvRwLKQP4WMpszxmblQWjMVbQxh7dwC+gPtqIANVjoGKMRfr6QpT03XXIEaTBKbMsxeYFvwn+y2JN30t6oFI6LJADZ22VwimEzu06u+x9c+3+pr4k7Py43OCOGmg=="
 
 [[package]]
 name = "libnetfilter_conntrack"
@@ -528,6 +536,14 @@ system = "archlinux"
 url = "https://archive.archlinux.org/packages/l/libnsl/libnsl-2.0.1-1-x86_64.pkg.tar.zst"
 sha256 = "2d9c86e58b6b59e0e3b7dc284d3dc8af6a671f81d13babf076dce6d43de02c52"
 signature = "iHUEABYKAB0WIQRizHP4hOUpV7L92IObeih9mi7GCAUCZSl8fAAKCRCbeih9mi7GCFsgAQCxeFyBcxhdhaDknYrn42Nnkm2P6CPMwqE7VGIbDQ1p2QD9EJK2Tyxncxt9jC+dNMC71fKzYavZvV3SVcp3M8J2VA0="
+
+[[package]]
+name = "libp11-kit"
+version = "0.25.5-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/l/libp11-kit/libp11-kit-0.25.5-1-x86_64.pkg.tar.zst"
+sha256 = "e3e16d93bda4890e19bf480d84f3b3c65c924b78287a3cc3da879721afc3c7a4"
+signature = "iHUEABYKAB0WIQSDvIiJNRtd67toQW64rAhgDxCM3wUCZob0iAAKCRC4rAhgDxCM34fNAQD99QMcqk78I4YJoOMvUYSWP5bp0NsB+zKALcHUAEjpMgEA4RSevlMjgPl0TEoMs/Pej3B8BkEfkxiDc3VMQ/7fxQY="
 
 [[package]]
 name = "libpsl"
@@ -595,11 +611,11 @@ signature = "iQEzBAABCgAdFiEErcih/MFeAdRTEEGelGV6sg8qCSsFAmX2sjsACgkQlGV6sg8qCSv
 
 [[package]]
 name = "libxml2"
-version = "2.13.1-1"
+version = "2.13.2-1"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/l/libxml2/libxml2-2.13.1-1-x86_64.pkg.tar.zst"
-sha256 = "3180fea4f0f9812f5da7408b06dff9ecaa7b53ee158e41d50323a24dab1d6279"
-signature = "iHUEABYKAB0WIQSDvIiJNRtd67toQW64rAhgDxCM3wUCZnLNaQAKCRC4rAhgDxCM31TIAP40xOqm5WBfm7ZV4io0bxTAAINGl8Pl5hZA9E0D+zY0+QD/eUWjNIusw7Ol9slq2KCduSOPJ22AJnZwNvhG4XJdXwA="
+url = "https://archive.archlinux.org/packages/l/libxml2/libxml2-2.13.2-1-x86_64.pkg.tar.zst"
+sha256 = "55d1e6e1b5241b83702a1e6252929c96782031cf2c4573ff2501aa4e51038394"
+signature = "iHUEABYKAB0WIQSDvIiJNRtd67toQW64rAhgDxCM3wUCZob0bAAKCRC4rAhgDxCM35taAQDEeCMlCAFLdli7Q2mqUXQBuhL9+fPlYZcGVwaP2kliEAD/X8ZpwxfcGzZdMhgsEUDK75GIzGdWu+deoJKqe7BvRQU="
 
 [[package]]
 name = "licenses"
@@ -618,20 +634,20 @@ sha256 = "90a7b061db393d9a6f68244f8772053f42d6cce586c561200d2586d4d662e504"
 signature = "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCZjoV/l8UgAAAAAAuAChpc3N1ZXItZnByQG5vdGF0aW9ucy5vcGVucGdwLmZpZnRoaG9yc2VtYW4ubmV0MDVDNzc3NUE5RThCOTc3NDA3RkUwOEU2OUQ0QzVBQTE1NDI2REEwQQAKCRCdTFqhVCbaCkbGAQDgE3AKw3Q01iehBZZsnkeeJItviKl5ymy9TKMrSeReXAD/QkZ9wK4v8R09cvnQPHfwnWV8Myhey1EIiDXnaKhp5Qw="
 
 [[package]]
+name = "lmdb"
+version = "0.9.32-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/l/lmdb/lmdb-0.9.32-1-x86_64.pkg.tar.zst"
+sha256 = "474c654b589b25f80b6bed806b6f5b79ff88f2052d9a54848299ef75a23e3dd5"
+signature = "iQIzBAABCAAdFiEEtZcfLFwQqaCMYAMPeGxj8zDXy5IFAmXLraQACgkQeGxj8zDXy5KzBQ//ainnkpc4j/YWOqY5bYu8BcIIrjk8dgEu4zV3w3QVQflJ160/x1vZPdcCsI5Ur3v9+dQvBYWgNfkSIrMNay+JeAkYpQ9a1MCaOlXoSmHmLUiyzVh9zNy5bY8yDDPNFUJf2oEyAKHvUFR7Fs0qxonqfilKKGehkJR1eSbPU1ZmDOcw5sjCHnZ8GUv8+rwoF4TABJnlvAaZ73YKdkmS3IQ+XQI98sv0rKbyLAM0s/ErBeI2WAx0FE9p19uyB5G8GRokFZt96zIqmHNUpCXbWeHmAIVcvDk2s6StHqywS5kEATLkHxLRaPQY2axVeluL/OGeHRyevDW/mYdwJgNa7Nlawgnq5PsyyLAdY310gYtwyx8HAMrhkEGOH1udno2sqmZ4vDpUjeSS1NPZ+4gq2/+Nk8KDlLj96IQHYnhV8PspcSG0Q9WCBWbVQ12r4K2+8XIO9gI8hg5/7kSevNz8Vcamcy84ezJpHZ88m+LpNLDmVL2BiMN6qMhMf+Ka3KeRyUgkDo9nZf9s/JjehkjGiKZJs74YnNzgPnKfeu53l2xyQw/QxG9kB0dOAGsiRFz/VZhuSyWK3cc60lvaMuDFjzSdMCuqAHzZrc0iVD412FZAtgE8Ek8Vi7XXhokwnXOT6Y3rSA5lpJhUPgI56Xfl5lXxD3opFN2shTaCe95KEsjcoag="
+
+[[package]]
 name = "lz4"
 version = "1:1.9.4-3"
 system = "archlinux"
 url = "https://archive.archlinux.org/packages/l/lz4/lz4-1:1.9.4-3-x86_64.pkg.tar.zst"
 sha256 = "aa92898d7ed44ce1929c1d59bd07c45afcaa7226fedb1772e0fd7672de499222"
 signature = "iHUEABYKAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCZfdwFAAKCRBtQr3RFuAGjxHcAQCUFpgmktTvH5FRfhqmUjciCqHPOPPw10/CD/X9aYEKxwEA4raaSN3gOj/ISaJmHb9NIwih+pxw132G5f7g+9F/mQU="
-
-[[package]]
-name = "make"
-version = "4.4.1-2"
-system = "archlinux"
-url = "https://archive.archlinux.org/packages/m/make/make-4.4.1-2-x86_64.pkg.tar.zst"
-sha256 = "7c1bc0d882f7c8d1bcb305eb7efaabc19ed6afa5a9a443575fa0d5ed57985535"
-signature = "iHUEABYKAB0WIQSZH24/B2XPYpWIhYYTmwnaW/DTOAUCZBT0lQAKCRATmwnaW/DTOKwJAP9/kfT3rO0NhbD8wuI6ajzjyKtrl4SfuU0yu/PKByXQOgD/aYSvsyXylJhCadU2smO4LbP2Vj9fnIvEwPvbXbesVQ0="
 
 [[package]]
 name = "mpfr"
@@ -643,11 +659,19 @@ signature = "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCZjqbXF8UgAAAAAAuAChpc3N
 
 [[package]]
 name = "musl"
-version = "1.2.5-1"
+version = "1.2.5-2"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/m/musl/musl-1.2.5-1-x86_64.pkg.tar.zst"
-sha256 = "914fc5796209750652303e830c6ddc2478ffa27261801592ac49f64a1456bac6"
-signature = "iQJLBAABCAA1FiEEiee5MxxK59f699MFwTIpOVS75K0FAmXjEw8XHHNwdXB5a2luQGFyY2hsaW51eC5vcmcACgkQwTIpOVS75K1yCg/+KLpAazqnCdR0qY6xNJM/v21L8B5Jl6+KIQCZ9NCTn0/33gQBCvMGghcx1WblzEslI6zjq2xHVzO7o2X2c3Vkl/XgsomY/DeXzK/GGVm+4yeyVe/M5CALqnzkHZiqEQvNkUW+7IKMHxmVWeXDhSWEv0k2SwEkl8K+Ge+BK1wdhXoj767YZXuf+09o8e6a4T1tLjauopBE7/7fXYD7/G0/UJueVQrFv72ouujL+Cazpv7vZfJYT8WjmhgPfHxBGKKNYzb9VICSw1jw6O1KAOd6b9j6kA+LkBYMkzFzCrVB3T5QXFSntUv2lBFvX03/E+1uTv3aAoBDFvaE1nveXODl35Tvh8/hyUdiKYjpbAY4nlrgjjgZF7ydL6cmv0KkhGNa6sVLANScKBRGjeGoHVWEIRLIeFG7KUymUPE6Yndak7Y6INr1lDH7gEqiWcVEd+27GstCk4g+dijrIV3PNer3JzJzBNYVxRXaIeIpSgn61tsca0KrmS3kr4j6fwX3K4ILBL4HcCsSCnk2HUFDtBlMiYGACsB/ue10MVmDZF1LDs8jxyrYLviCgR7e6iENAmkbd0UhQniC0vG2HiAJA2K6IYk9btw4ItUtFUdm7OnIcJlIt6LCaa9V3IJ87uZIPNlWCGZxPLPMyByCAGSOOvmYO5U248Sknqs4FFDGKVsrHAo="
+url = "https://archive.archlinux.org/packages/m/musl/musl-1.2.5-2-x86_64.pkg.tar.zst"
+sha256 = "146b60543069d4eb92fd9086ffd6f442ee0a1f41f724445adc29af80693ce2da"
+signature = "iQJLBAABCAA1FiEEiee5MxxK59f699MFwTIpOVS75K0FAmaUdzsXHHNwdXB5a2luQGFyY2hsaW51eC5vcmcACgkQwTIpOVS75K2C+g//ddIjb7CKai01nuuzLd9hZQBP51iBe+lYdhv5lxlKaSzQZXHVUGXDAZdb7TaV9pbzdGPE+l5V2ZngivXdR5twUDWOQzvorXdxLgX7trBTghLDTBIKu6jPtrH2bNWrL8A908RumQVeWsOxUcompgAsRpQ4DhZkzk8325k9et0Nv1oQic96B5G1WefE85IYc2PDJeRhfyfnZmQ15aoVhohyhF0XSudlJSc/hqMZePW8tmyYz4ltvgOs4EF3smNwOaZVOew+w/5vOCYaSre5MFwHiilvYJaWhCji10m0MrBzLhRx0ZfRlBwTGbsToRbmczuwMXoYIiJsI2OiXsZD5/X9T5yPjl7pWP7uLaNTXCcbfrCZIWMVBXYQFxnWhUbKFZu8E7eXU2z75GukkC7GjR+VKw+SFH06Xdq73JltIXURRKe03uigC8ciME1xHOMv5kc1pQukQC/hTaR4GPF32pOX27CPQkNQ0dhRi1Cgyt47V+3GncI+mhlY3gJsCv31+Z0kM+WornVJYFSQnO0/frFPJaZUt0ONO7lHU2UMTe2tHm+zFHuHh6xOGaMjdRslrzq0Pby0xMb6nT0HsT1VXfSW30rywN1UPLd3TxAXGkG3SS8szftrLrmK6NAsK5tWfd5H2tiwSibYNnYYYVB720LKBl7bgpGFicdROohXJKqXsvA="
+
+[[package]]
+name = "musl-aarch64"
+version = "1.2.5-2"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/m/musl-aarch64/musl-aarch64-1.2.5-2-x86_64.pkg.tar.zst"
+sha256 = "a127125a8b889341e8ee1d9a68b75b7afbc7af9a13e0203c460b5bf266084df3"
+signature = "iQJLBAABCAA1FiEEiee5MxxK59f699MFwTIpOVS75K0FAmaUdzwXHHNwdXB5a2luQGFyY2hsaW51eC5vcmcACgkQwTIpOVS75K3i7xAAgtV4szRrzrfudev6aAAIeGUMMmYRuzSjicbS8+2jMdJUTeWkHRpEWkA/f+T29ki9OlJAHzotThWREgetwkoXrovUfugb0MNY++u4Oo3N2Z72AS1ndweWy/0ewz/0sOuVn6NNfTek8BhXa9lzhPLbd+JLRHXqlt4gz6tS8ax9aiXuUqKIqjo00HTfwiMYyaUbRx83eJL/0549A2Rq72Ju7vDIBnRe2Bf5brYkRBluVbOKgEEEDJ63pwzzw2K694YJyIzGmeLf5ZKG2dVyQZ9RoR08bwMXGKt7qInijgbDozNp3GOdvVL/v4wMByc1TjqazycJmSgKqFALgLxBsxm9LjT+j2OCpz5imS4I1OecuJSO5bTHZNhkgE9rqsGdjVNUjLSgvQem/k8OdIWrnF5W7bfCZEI7EUI5qxAG3uh6jCG/LEJkjIuR7IN17sDtl50DcPpN/Sr4wcETXfoz1NNB3b8ZwBITkADBnDu+lmG2+x7pPXicZSVOPN8i1IYnq8r11Aw1GxOCXQZsGfsJgByjWYs5iD1Y/8JLlsw7aagwjZoh2bMGadlA+tzY83+2OP2Nq4Vrhwum96ec7vUoe3kKADJ0751IHW3+anqglMivyOXmngBObAcoWb/Q1HrTMTQy6SGemdM614Yw/h+tJizeOvugkqbX3gny7grDrIgmjRY="
 
 [[package]]
 name = "ncurses"
@@ -680,6 +704,14 @@ system = "archlinux"
 url = "https://archive.archlinux.org/packages/o/openssl/openssl-3.3.1-1-x86_64.pkg.tar.zst"
 sha256 = "3d0540fb0d4196c9d8bc369c7d2faa8800a37d4f57e4b3cb418dd438fd3c59dc"
 signature = "iHUEABYKAB0WIQQ+gMoai4n2nLpX2Yp2pe+QVESaXAUCZl9thAAKCRB2pe+QVESaXPZ8AQDIUORLQtyVcPznVihzQAv8blUov4Hed21VTKr3xyrI2AD/Vsb6QEV/ITwbEk9hKgi4rjruYyMaDUSliBd9XQL7PgA="
+
+[[package]]
+name = "p11-kit"
+version = "0.25.5-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/p/p11-kit/p11-kit-0.25.5-1-x86_64.pkg.tar.zst"
+sha256 = "fddfcb0eede8619d1185f9834426c27db68407fa5fb2eabd4cba360116fa536b"
+signature = "iHUEABYKAB0WIQSDvIiJNRtd67toQW64rAhgDxCM3wUCZob0hwAKCRC4rAhgDxCM3/AIAQDWuPLCUdBREcAK7E0Yjz7ZhXdoF1yd4u4PcMuswFhNYQD9GmxAlIR6t0FGFkqGzr3nzImV0pb0v5t8Sb0OPLrBsQc="
 
 [[package]]
 name = "pacman"
@@ -816,14 +848,6 @@ system = "archlinux"
 url = "https://archive.archlinux.org/packages/u/util-linux-libs/util-linux-libs-2.40.2-1-x86_64.pkg.tar.zst"
 sha256 = "f2b27ad8987bd146aa9431aec36cbd73b0a820c4996b91cac15afcebd96ea399"
 signature = "iHUEABYKAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCZoZctQAKCRBtQr3RFuAGj94rAP0ZLhpNPjBwnpon0hlXT6gKrRAxiD5BdsDCPjSTA5B2rgEAhjBvxUGHDD2X9meZ0uE8ilKpjjmyQtBWHASwab5VBwo="
-
-[[package]]
-name = "wget"
-version = "1.24.5-3"
-system = "archlinux"
-url = "https://archive.archlinux.org/packages/w/wget/wget-1.24.5-3-x86_64.pkg.tar.zst"
-sha256 = "fd928001f09cf506f5db8614501d49abea2c18e6546140db9bac450cf0e60b80"
-signature = "iHUEABYKAB0WIQRUwf0nM2HqUUojd5Pylr3lA2jGzgUCZnw1DgAKCRDylr3lA2jGzsANAP4zcY+oGqNvPyR4AVVGPESLblBvPrvq2PuUAh5edlgPRAD9EaxkTGK1BxQh5ssBmf3+fvYDnbJjEhy1ZCBWbtriGwU="
 
 [[package]]
 name = "xz"

--- a/pkgs/sn0int/repro-env.toml
+++ b/pkgs/sn0int/repro-env.toml
@@ -7,8 +7,7 @@ dependencies = [
     "aarch64-linux-gnu-gcc",
     "cargo-deb",
     "gcc",
-    "make",
     "musl",
+    "musl-aarch64",
     "rustup",
-    "wget",
 ]

--- a/pkgs/sniffglue/build.toml
+++ b/pkgs/sniffglue/build.toml
@@ -18,22 +18,6 @@ set -e
 # 2024-01-01
 export SOURCE_DATE_EPOCH=1704067200
 
-wget https://www.musl-libc.org/releases/musl-1.2.5.tar.gz
-echo 'a9a118bbe84d8764da0ea0d28b3ab3fae8477fc7e4085d90102b8596fc7c75e4  musl-1.2.5.tar.gz' | sha256sum -c -
-tar xf musl-1.2.5.tar.gz
-
-pushd musl-1.2.5/
-CROSS_COMPILE="aarch64-linux-gnu-" \
-./configure --prefix=/usr/aarch64-linux-musl/lib/musl \
-  --exec-prefix=/usr/aarch64-linux-musl \
-  --enable-wrapper=all \
-  --target="aarch64-linux-musl" \
-  CFLAGS="-ffat-lto-objects"
-make
-make DESTDIR="/" install
-mv -v /lib/ld-musl-aarch64.so* /usr/aarch64-linux-musl/lib/
-popd
-
 mkdir -vp ~/.cargo
 printf '[target.aarch64-unknown-linux-musl]\\nlinker = "/usr/aarch64-linux-musl/bin/musl-gcc"\\n' > ~/.cargo/config.toml
 

--- a/pkgs/sniffglue/repro-env.lock
+++ b/pkgs/sniffglue/repro-env.lock
@@ -43,11 +43,11 @@ signature = "iHUEABYKAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCZbDRHwAKCRBtQr3RFuAGj1S
 
 [[package]]
 name = "archlinux-keyring"
-version = "20240609-1"
+version = "20240709-1"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/a/archlinux-keyring/archlinux-keyring-20240609-1-any.pkg.tar.zst"
-sha256 = "1498cbf8f9511a7c4f52b40b392bf8779e9543195f2a0a95a9dcda7b49dd0f9f"
-signature = "iHUEABYKAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCZmYV4QAKCRBtQr3RFuAGj5TKAQC4YJtPS54Mbb1HpkGBtt/rnHcZJwCTGkZ5oyPcWqen+QD+ICYfcLg4P1+sj+hMfPmDXQf4aKBLDrFkKKvSvCgy6wY="
+url = "https://archive.archlinux.org/packages/a/archlinux-keyring/archlinux-keyring-20240709-1-any.pkg.tar.zst"
+sha256 = "a6f573fc97fc21b55504a4d75d010257792847a5b87f19edff4ffb662f6f53a2"
+signature = "iHUEABYKAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCZo2s1wAKCRBtQr3RFuAGj9MSAQDCI730nuxWZ70VM9xGZZZDyLwb6LdAN+fbUdkNzaE3wAEAsNqHKFnUKRnBXwGOv3j8VrP+XaGD0P2QJAEocEeWiQM="
 
 [[package]]
 name = "attr"
@@ -123,11 +123,11 @@ signature = "iHUEABYKAB0WIQSDvIiJNRtd67toQW64rAhgDxCM3wUCZnHT6wAKCRC4rAhgDxCM32T
 
 [[package]]
 name = "cargo-deb"
-version = "2.3.0-1"
+version = "2.4.0-1"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/c/cargo-deb/cargo-deb-2.3.0-1-x86_64.pkg.tar.zst"
-sha256 = "537a26f5a9b057689f42b7b37cb903c95ac0b982908e237e20a652c577246fbe"
-signature = "iQIzBAABCAAdFiEEFl4P98SMIm4ew2On+DQkgks+S5AFAmZrA44ACgkQ+DQkgks+S5AOeA/9FVP0P9inRSQTYfG9VphaTxS2MIB6+HPOR5AaV5z/M0fSO8ux92vtbQcWMKrccttwk5rL6evxJAkMzYSXRJ9Gdua1yYCO8yJ+kr1rffvG/SafCBsnkvoyM+2CAgSwnBWDkWUm7MljyyyNMswcj3WIIrikdJVAKzanzSONlCeioF+zZM1ODZe1N4GVA3A9JlbDuAFVJkzlpqPkLYLr6iAPYyLjHpbPfOhnyDcTJDoDmH8kUWGXPt2W2J7OIIRtrYmUpevG0AS5X6+D37dxmi3qtxeZPnskUiSZ6kbdHLhdAQnte8XkfRUYZ+LtU/YBzjbC5QiKj/9RE/2Rp7NkcdJk/MreolKhQqbVYFNzKYeJamJaNj63fSGKL3X83NYY62w0tS89qRv1AklbLU84Ilutw3YaBTmdlyVSvzYSmfqMie7w3brwQAVRGysyvdMh3K9gMoGZuXpDXE08PQwWtY1h9Q1MmSx8bKWg60VEyLhS3SK5/PjvuS3/6YGgQa1Wxy6lIqSY1wKRg6WlyU+RM8S9Dl5Gtlr6jYAJvkFKgEy1It7UdR5vhPw+DQfb9LIzJnON644qteOhCKJQIEH/JGGH820V3Gq+20jPXjYb7oQoqimnB52yJI53FY/jdX3OsCpE7fojqpBWeLLZ2KKBcSsqwBO2hpNojnuOtCJZyw23BF4="
+url = "https://archive.archlinux.org/packages/c/cargo-deb/cargo-deb-2.4.0-1-x86_64.pkg.tar.zst"
+sha256 = "6b0a76d71961c376129b79d81d318ce9cb401dd21796bf642b8950092cc559c7"
+signature = "iQIzBAABCAAdFiEEM+u4qOHFZTZFsSMqRaZQ4mOMU20FAmaLye4ACgkQRaZQ4mOMU21+Sg//SneMbZek0hl1LONnsp1BkJ4OAxHD8KZ7ZUVgNqoKxFo7Y/vyEnY1QKo6BLTikH6MheSvXhWpdLpNnqXEJj8QA46HNCjaU8rugq0EPJ3meB8I+7qnlelCTwNWIB12UVvOjCm1mR5ux96W/BZjN3Ur7jfQlEHjYsM6ToL+tq2HitkNdQvKO0L6dyQC3FbfqZsi37nBdv7gQKh5IjV0beZ6RReEyEuzBC1Uio3HN3IuStZMSmxiXgpITjwLkHHztNFub0hhQO69065l4CFueqci0aNtkp5xoXF8Qflwui9f0MdxUc8m/5sdf95NTDFWnyh8MnUs3/qqPY6FyQ1uaaf8TxGspO0AQYzkLthe50wEd9aChCinU3x8/17p909u70fGVU6eBqMPugXwzrrHGOJ8JLviUQuGC8kOWvtuEt9oRHnwetWCMVWNcUVHCIl4GG5DBzHPeNP9li8TSoHW8RV7EbxVEtzSnfXxWh3tBRfau0ugxgVlmC7Dn+/wt5PxAXIGZP7MqmRyzBJYVG7vWBHdPFzUEJD0n0dL8IwOWOvbhG4cZ6yfiGHt3yzgbrIMUsDsqdeS8B7EteyAWmNaAkTiuiV58qsy6IfE86b//hfq/NlpKRzuDx+vVlJAYoEfZBblw6k3txlDb1YHc6NQ4PeVFTnQKNDb+WFMSoai4OPxEjg="
 
 [[package]]
 name = "coreutils"
@@ -218,14 +218,6 @@ sha256 = "f7d9994d70d5bac0e99a66508673abba271d1b0b0598e001b7a677d182663500"
 signature = "iQEzBAABCAAdFiEEW34/txt/EDKaHAOrdx32Yn7faB8FAmZbgL0ACgkQdx32Yn7faB8F/ggAt6EqPhQ7KsinXsEEJhE+ammbeflgv4eKpmhP6wlfnb0Cg3TerAKdEbXUdR3rpcztE2f/zLJ+Fs9dYV5DOqcMV5cpLWD0NYjo/SmiZMVjM1/ZWskbnhyMAsfDQwUXXZYruMiOGdMpJFu8sqKBkQqrd4cOkn3AF2r2wXW+PF2r2yb0K9mv6YW285RIEo7aphVsI0LZgKbrksDeMbWQF3U3A1WHrVX1rDXPB0CSnxkIaEm3erzaFj8dhrFd4/7k7iIUjLFP2Ev6HhBjr0CA7V62LtJ9EOyGtYCY7SB4SKL8EWdWJK513jpVe6gu/5M5A3H0zmA8w5E83zW/Z5nbZvnFkQ=="
 
 [[package]]
-name = "gc"
-version = "8.2.6-1"
-system = "archlinux"
-url = "https://archive.archlinux.org/packages/g/gc/gc-8.2.6-1-x86_64.pkg.tar.zst"
-sha256 = "6210a1e7e00d3162f175f9ab318a3da928495210b1ea411dcb66bf5e1f382daf"
-signature = "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCZb9oiF8UgAAAAAAuAChpc3N1ZXItZnByQG5vdGF0aW9ucy5vcGVucGdwLmZpZnRoaG9yc2VtYW4ubmV0MDVDNzc3NUE5RThCOTc3NDA3RkUwOEU2OUQ0QzVBQTE1NDI2REEwQQAKCRCdTFqhVCbaCmQdAP0fleaFihboUqrAdlMxvO5OUJiXXxLtimhQj2e3rD9L3gEA0YzMCzi4GS6GlV1pa/hZ68bPL2gYz2goni9/aLXhMwY="
-
-[[package]]
 name = "gcc"
 version = "14.1.1+r58+gfc9fb69ad62-1"
 system = "archlinux"
@@ -242,6 +234,14 @@ sha256 = "7605cb1ab1830dbdd564591d33adeec78ce79c1733bd98f36ba3e81eb9748b78"
 signature = "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCZk3zsF8UgAAAAAAuAChpc3N1ZXItZnByQG5vdGF0aW9ucy5vcGVucGdwLmZpZnRoaG9yc2VtYW4ubmV0MDVDNzc3NUE5RThCOTc3NDA3RkUwOEU2OUQ0QzVBQTE1NDI2REEwQQAKCRCdTFqhVCbaCugeAQDgJyrXuoZnSZFU/gz5rGccNOuGSgOvfYX2YTY1drfb/AEA4pmZIr4MJC/1XQF5AmrhxTX491TtbJgxdstI+1KysAs="
 
 [[package]]
+name = "gdbm"
+version = "1.24-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/g/gdbm/gdbm-1.24-1-x86_64.pkg.tar.zst"
+sha256 = "2712f2747f887ff19ad4151143e506e80254a0a0db0e8b968adb6634da7800ab"
+signature = "iHUEABYKAB0WIQRizHP4hOUpV7L92IObeih9mi7GCAUCZoa2fgAKCRCbeih9mi7GCKXhAQDIaNqIfZ2hIa29L7FE1axM7Ui45KQxU/XOCC2cnzisvAD/aecNLEqMxSnE/FsOhZdi0dAHLAuOjVRSpF6IbtF1NgM="
+
+[[package]]
 name = "gettext"
 version = "0.22.5-1"
 system = "archlinux"
@@ -251,11 +251,11 @@ signature = "iQEzBAABCAAdFiEEW34/txt/EDKaHAOrdx32Yn7faB8FAmY7WIYACgkQdx32Yn7faB9
 
 [[package]]
 name = "glib2"
-version = "2.80.3-2"
+version = "2.80.4-1"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/g/glib2/glib2-2.80.3-2-x86_64.pkg.tar.zst"
-sha256 = "5097ae4a68ce205c4ffa370d5d9ba3e4ad9afb97d61e3d3f61d9b944813e7ad4"
-signature = "iHUEABYKAB0WIQSDvIiJNRtd67toQW64rAhgDxCM3wUCZmjHogAKCRC4rAhgDxCM30ONAQDMZoZSkJDOZDPD9PMLvhbK1VJxJp8VRgdxG1OILR9kfAD/evaIoFqw0LCQaTkKdSavJURgzmjh9g+LJ4FM7OnIzwA="
+url = "https://archive.archlinux.org/packages/g/glib2/glib2-2.80.4-1-x86_64.pkg.tar.zst"
+sha256 = "047121788777ae88726ee10525fba0ab05cc495cdb336a45bea6cdd0793c8d06"
+signature = "iHUEABYKAB0WIQSDvIiJNRtd67toQW64rAhgDxCM3wUCZoxhigAKCRC4rAhgDxCM37jmAQCMi355gHS4atKFg2Zr5R5hElvjlTp2vx7s2MniqS4usAD+KrBXRueBCElmnuplANh2d71qDwjAG7FFueZk8bp61wA="
 
 [[package]]
 name = "glibc"
@@ -296,14 +296,6 @@ system = "archlinux"
 url = "https://archive.archlinux.org/packages/g/gpgme/gpgme-1.23.2-4-x86_64.pkg.tar.zst"
 sha256 = "e2a1b35695ea4d88fc19e74bc554b7f45f0731e7028e066e4100354586728973"
 signature = "iHUEABYKAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCZiYi2AAKCRBtQr3RFuAGj2U+AQDvXt3MzYy4Fm+Nu1lul/pTYW3pIdGh7SZ2pvkMHNhUXgEA8moKzHQLFtW6g51MSFbUz2pMunFR1Bbv7DzNzgV7GgI="
-
-[[package]]
-name = "guile"
-version = "3.0.10-1"
-system = "archlinux"
-url = "https://archive.archlinux.org/packages/g/guile/guile-3.0.10-1-x86_64.pkg.tar.zst"
-sha256 = "bf4d1b474045a88c7ad97b1ce56e8dd5786e5a10de02a8d33dc8f041edc8d01d"
-signature = "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCZnkshF8UgAAAAAAuAChpc3N1ZXItZnByQG5vdGF0aW9ucy5vcGVucGdwLmZpZnRoaG9yc2VtYW4ubmV0MDVDNzc3NUE5RThCOTc3NDA3RkUwOEU2OUQ0QzVBQTE1NDI2REEwQQAKCRCdTFqhVCbaCruHAQDnjJsHGhq4cae34rHS1z+Hr6yzjVQSxvA6SE9XpredlAD/cstobLSMUsHswxf5df94XkoDPJdJs44uXE/iu9gsgQg="
 
 [[package]]
 name = "hwdata"
@@ -362,12 +354,28 @@ sha256 = "a67ab57d4a9b4caa2e718652c392345cdd9c2496d835ab1d0ff1e78ae4429fde"
 signature = "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCZjJful8UgAAAAAAuAChpc3N1ZXItZnByQG5vdGF0aW9ucy5vcGVucGdwLmZpZnRoaG9yc2VtYW4ubmV0MDVDNzc3NUE5RThCOTc3NDA3RkUwOEU2OUQ0QzVBQTE1NDI2REEwQQAKCRCdTFqhVCbaCpfCAP4sFnTjSEIn5wDbLWGZOivsWT2SWPG6AgofrnUjaK/UMAD9E2u6D7WJbVTYrvDhVUz3WN6k8bVB8ZODyoIF66GWEw0="
 
 [[package]]
+name = "json-c"
+version = "0.17-2"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/j/json-c/json-c-0.17-2-x86_64.pkg.tar.zst"
+sha256 = "0ee6f3e674fa37284edb7bc5be69aade405324e661edeeb101c6be635d029eab"
+signature = "iHUEABYKAB0WIQSDvIiJNRtd67toQW64rAhgDxCM3wUCZoXErQAKCRC4rAhgDxCM34XoAPwMKnwAuDrtCO9vaS+0HJOosrxMtGWqC2xPrmNtS5juWgD+PUCrtolVhKWx+DJWo+7+3Jl902VOZozp21TMjUcUUQg="
+
+[[package]]
 name = "kmod"
 version = "32-1"
 system = "archlinux"
 url = "https://archive.archlinux.org/packages/k/kmod/kmod-32-1-x86_64.pkg.tar.zst"
 sha256 = "9abd6fd54052b48b2bac6e709e25e7be876f68d84949ed4615a3fb8803f2a736"
 signature = "iHUEABYKAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCZegwsQAKCRBtQr3RFuAGj3QXAQDqrsXu36gY3rprKLSh3b3O0VYDQk7UHHSCAveZEHpvxQD/dR6SLukPahSQ8LABJmCFHk4w4d1PgBDRCczcaMYR2QE="
+
+[[package]]
+name = "krb5"
+version = "1.21.3-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/k/krb5/krb5-1.21.3-1-x86_64.pkg.tar.zst"
+sha256 = "7ce8f30ccef0650b964defb7a539c72d5e40fcd288f5f397c1b824d3f4431b2b"
+signature = "iQIzBAABCgAdFiEE4kC1fixGMLp2ji8m/BtUfI2BcsgFAmaJc6UACgkQ/BtUfI2BcsjO0w//R4djAXEL1QcOF/Jh4Ukqy+k+AhvnNSJN5JPhOkvJKc7DqCudBaFcuHdGno6KIAyg42q9PjeIBWxH2kcIVojmGZ+zPvscdX0mjwJAxZ+tBDfa54eOqtnUMGbPDL5QoGeZjfhdQ0hHOFDkpioz8c1hVjdTRvqkC6J5uUGH2SQmD9HfBUFv5O9g/QW+JJI4kXFYnewZewrDOFAccYFjcBjioY1L898+2freJ2JOIh5acf1mtQol/cZhOQevQ/SdZ+BsYZOLp3QFU+IE4Wg+3h2ayEa88A7i/U6ln03GkYNySY1UmqKwrALE9ixW8BSKXoVldtjyiLFH1PHsr0QLmn1IBEt0bis5L059JEdaCv8JKeEElQORUQNLXS6fBV/Oo4oc6mI0SiyOvMPchwkrgvSkh2UKz4AGtpan5EvwRDdaNdhZiCVEDWLIZ6sm0sXRIoJzrB4SsCux9eZnma6Yls47PjgR75ZFbNCr/CHHpZMHyL7mjb8fpZl12mXRcRAMo+3laZsJxUUOymtf3gb/SKQ5rDlYfHxtFaoRvUzKOscUT1d5PQ90KAuD0rbRmUynxBd4FqLAPs7xpcFJtboAsLd1Iax04gAxNtmQQ9F2SujJD+h/LoPwtqu2rU07e9+rcXtKqwYqTxH8TDGpEERsxkUcaLkvsz3sOxIEAUzubYnBn4I="
 
 [[package]]
 name = "libarchive"
@@ -387,11 +395,11 @@ signature = "iHUEABYKAB0WIQRizHP4hOUpV7L92IObeih9mi7GCAUCZgqJbQAKCRCbeih9mi7GCNv
 
 [[package]]
 name = "libbpf"
-version = "1.4.2-1"
+version = "1.4.3-1"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/l/libbpf/libbpf-1.4.2-1-x86_64.pkg.tar.zst"
-sha256 = "70e86fd8bf8e6a0850eed15a580376049d988a28e987afa4c311abd2b1af611c"
-signature = "iQIzBAABCgAdFiEE4kC1fixGMLp2ji8m/BtUfI2BcsgFAmZSc7YACgkQ/BtUfI2Bcsg/HBAAu1v9RTktILD/N34CyIuLCDci6qPeEC3oXDIpZLBnXTwcIwo2Hhhn5n3Sz+k/Tbb6gRMIRhsnqwpxANRo38B9QMODyfeM4wKDNusV1cYUtE/9X3g00dHOYwDu//a/eLj7vHnUWTnFT3zebtRqFUtsFCKr1gogppkQzKCuYx7Nhrl/Z/1md7LEQZXxKWt9d4VSjex4noNMu+7ZujWKZFfYjyPyBzX2mDe96VEBT8BGnMzMjHT07Z7094BAHmVBrNmaJYxkNn34zhMAnG03Lxq93RHgnRJ3K7yzx+rRuEwsqg+7w/47nvgq6K0EaB04jQ6HbW/uIAn3sWIYgMZFIeBxeiCn5qQsNH0u7kSy3fivVuKADmVNG7UphHa3CVcSUi+9nSgt7Ug1RM3vsfX6c/+OiJnQoDHl/ITNZTsmMjc+H0jcJf+3zHyLnKObgEDOTehixOHWUnA8I0MgGCWDeXD8AwSyFl1kponCDgFbrVBwWgv5YvS0lvgTnRo65ix2g/XhVCeqLmgb42t5lnA+QSoRmY21CGalMF1JNvzMwhRr0ZTslbr/OUphjumFylhRcH89QX5HD1UZcq/tbECWsenQiVycN/4iKA0tebCQVyfiqC9yf0A0cKgl4G2gyAO1nN0iZ/5k8zBglcmAksi8xzfeLpGCs36wYnC9Z+HzvEV6StA="
+url = "https://archive.archlinux.org/packages/l/libbpf/libbpf-1.4.3-1-x86_64.pkg.tar.zst"
+sha256 = "5c265558f023b70a5bf91a18a8ef91ef997b76937aff1e02899e8a564ba9df43"
+signature = "iQIzBAABCgAdFiEE4kC1fixGMLp2ji8m/BtUfI2BcsgFAmZgmLQACgkQ/BtUfI2BcsiYVw/6A4E4pNMMnrAQpVElsIoe5mgGjKFiZSQiveupLzqETBHfR3tEo+4pSd/K5COOg0OcZbnVf0QQhWgAlHZwszQdbiqTO6QRRvs8D19g2cDB1id0QjetR5Psxiblv97nOwsD0VSERBZ7DIeD+ssZJs+q31P9fF9jlzXYWV6tlBvSCNRc3vS7ShpO/oFm4SriKbJb5/luIPA4vY/JkPN/LUn5kEc/mqynt8yX/xTA1cnF23YNQ9lc2J8ZMYi30guLbFlRjeXgjaPYYxjYZ6A8j3ua/06VFEhjgCno6WUqBt2qKwZzcra57SKoUh7COah18rHQN+4IxGAW6LUPTvaghWiMFA2Be/R1itx72S4AlXym9/7KLs1mrG4YEeCbq5XYfhCec3oie0dfyKmOT61QhrymLlu7EwkDG1neqk+xo595up7m18q3tdiCPRx+AQZd9cxM1+wgjje2ZNSLRrP076AEZenLYADxhhnL5Omr70d7mGZooMjMu7J4AWxfWXmFYZYxhaZ9ywbWnfJJhkdFPuczOZU38Am0lCZpRSSPt3IYxTxzpQt3esSzhXIOTzH67P4ef55TeIqojzhdXcX8mr1J0LJGduG91lfMTb7X2tiEq8XAGmYHEpMt4VnfdG+wyMLCQXzHWAu1CzDcxBNft79rJE9xaKC/9550FsBkERN501Q="
 
 [[package]]
 name = "libcap"
@@ -483,11 +491,11 @@ signature = "iHUEABYKAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCZfdwygAKCRBtQr3RFuAGj3a
 
 [[package]]
 name = "libmpc"
-version = "1.3.1-1"
+version = "1.3.1-2"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/l/libmpc/libmpc-1.3.1-1-x86_64.pkg.tar.zst"
-sha256 = "a83324a476cae86887aa3e3811b2e72c31471a81be0254e379c244e2df531c1b"
-signature = "iQEzBAABCAAdFiEEFRnVq6Zb9vwrc8dWek52CV2KUuQFAmOfE/EACgkQek52CV2KUuRNEwf6AkQRJ6MKo3+8qZ5DoL1AUfEbRy332+0DbmhqVAZAVR6SDYwr8yTYc5L9zWtRYA++Nh0zah4P6o3XXJISOfLLpQHGPI1jZ/1IGTJlCt0yo+KU891YfQQO95TCAa77oT9Njkxr6imF0vP5kR3PA5sEvqD0iCu69s0TQu2uzsVqigNmbWU3LVv47BrF1T+C31Oa6cRWmjDUtn2ls/jYn+BPvuCO9TyH/3d2lQ1CCM+H1cCDcxzBSmaYSVQUbM6x8YAdFKDZKEbwuiCGTwKIV5ZRar4UiiBdeuJzF0vSy51VdcZpvf30HU8VuJ2Q+mv5OfyHjt/HBCkEyn1b+XufIqb0Xg=="
+url = "https://archive.archlinux.org/packages/l/libmpc/libmpc-1.3.1-2-x86_64.pkg.tar.zst"
+sha256 = "10554706eb15ed2186fbd55fd5db8fa5919788ac9a75d26c0b9ef5bdfca9d470"
+signature = "iQEzBAABCAAdFiEEFRnVq6Zb9vwrc8dWek52CV2KUuQFAmaHCZwACgkQek52CV2KUuRjbAf/TmL9cCMXYTGsNmR2om6kT7XjczfZoFR9AM0FSTUNy5AuNZNUUCfm6ie6F4rFwHc3nETOSojScOZauZlcNiLrVriHYYFSZ8EhKiCJCo68a7KTbceBNoBuT6AEIpGMpIMti/cvWhu8VXl5JIRo8LNPBzDih05aCDUJ2nayKPYNHalDayu87sDXzJYXuzC8KD7XmUa7Kirn0ZpA4VZXc8CUjYYvn0wvRwLKQP4WMpszxmblQWjMVbQxh7dwC+gPtqIANVjoGKMRfr6QpT03XXIEaTBKbMsxeYFvwn+y2JN30t6oFI6LJADZ22VwimEzu06u+x9c+3+pr4k7Py43OCOGmg=="
 
 [[package]]
 name = "libnetfilter_conntrack"
@@ -528,6 +536,14 @@ system = "archlinux"
 url = "https://archive.archlinux.org/packages/l/libnsl/libnsl-2.0.1-1-x86_64.pkg.tar.zst"
 sha256 = "2d9c86e58b6b59e0e3b7dc284d3dc8af6a671f81d13babf076dce6d43de02c52"
 signature = "iHUEABYKAB0WIQRizHP4hOUpV7L92IObeih9mi7GCAUCZSl8fAAKCRCbeih9mi7GCFsgAQCxeFyBcxhdhaDknYrn42Nnkm2P6CPMwqE7VGIbDQ1p2QD9EJK2Tyxncxt9jC+dNMC71fKzYavZvV3SVcp3M8J2VA0="
+
+[[package]]
+name = "libp11-kit"
+version = "0.25.5-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/l/libp11-kit/libp11-kit-0.25.5-1-x86_64.pkg.tar.zst"
+sha256 = "e3e16d93bda4890e19bf480d84f3b3c65c924b78287a3cc3da879721afc3c7a4"
+signature = "iHUEABYKAB0WIQSDvIiJNRtd67toQW64rAhgDxCM3wUCZob0iAAKCRC4rAhgDxCM34fNAQD99QMcqk78I4YJoOMvUYSWP5bp0NsB+zKALcHUAEjpMgEA4RSevlMjgPl0TEoMs/Pej3B8BkEfkxiDc3VMQ/7fxQY="
 
 [[package]]
 name = "libpsl"
@@ -595,11 +611,11 @@ signature = "iQEzBAABCgAdFiEErcih/MFeAdRTEEGelGV6sg8qCSsFAmX2sjsACgkQlGV6sg8qCSv
 
 [[package]]
 name = "libxml2"
-version = "2.13.1-1"
+version = "2.13.2-1"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/l/libxml2/libxml2-2.13.1-1-x86_64.pkg.tar.zst"
-sha256 = "3180fea4f0f9812f5da7408b06dff9ecaa7b53ee158e41d50323a24dab1d6279"
-signature = "iHUEABYKAB0WIQSDvIiJNRtd67toQW64rAhgDxCM3wUCZnLNaQAKCRC4rAhgDxCM31TIAP40xOqm5WBfm7ZV4io0bxTAAINGl8Pl5hZA9E0D+zY0+QD/eUWjNIusw7Ol9slq2KCduSOPJ22AJnZwNvhG4XJdXwA="
+url = "https://archive.archlinux.org/packages/l/libxml2/libxml2-2.13.2-1-x86_64.pkg.tar.zst"
+sha256 = "55d1e6e1b5241b83702a1e6252929c96782031cf2c4573ff2501aa4e51038394"
+signature = "iHUEABYKAB0WIQSDvIiJNRtd67toQW64rAhgDxCM3wUCZob0bAAKCRC4rAhgDxCM35taAQDEeCMlCAFLdli7Q2mqUXQBuhL9+fPlYZcGVwaP2kliEAD/X8ZpwxfcGzZdMhgsEUDK75GIzGdWu+deoJKqe7BvRQU="
 
 [[package]]
 name = "licenses"
@@ -618,20 +634,20 @@ sha256 = "90a7b061db393d9a6f68244f8772053f42d6cce586c561200d2586d4d662e504"
 signature = "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCZjoV/l8UgAAAAAAuAChpc3N1ZXItZnByQG5vdGF0aW9ucy5vcGVucGdwLmZpZnRoaG9yc2VtYW4ubmV0MDVDNzc3NUE5RThCOTc3NDA3RkUwOEU2OUQ0QzVBQTE1NDI2REEwQQAKCRCdTFqhVCbaCkbGAQDgE3AKw3Q01iehBZZsnkeeJItviKl5ymy9TKMrSeReXAD/QkZ9wK4v8R09cvnQPHfwnWV8Myhey1EIiDXnaKhp5Qw="
 
 [[package]]
+name = "lmdb"
+version = "0.9.32-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/l/lmdb/lmdb-0.9.32-1-x86_64.pkg.tar.zst"
+sha256 = "474c654b589b25f80b6bed806b6f5b79ff88f2052d9a54848299ef75a23e3dd5"
+signature = "iQIzBAABCAAdFiEEtZcfLFwQqaCMYAMPeGxj8zDXy5IFAmXLraQACgkQeGxj8zDXy5KzBQ//ainnkpc4j/YWOqY5bYu8BcIIrjk8dgEu4zV3w3QVQflJ160/x1vZPdcCsI5Ur3v9+dQvBYWgNfkSIrMNay+JeAkYpQ9a1MCaOlXoSmHmLUiyzVh9zNy5bY8yDDPNFUJf2oEyAKHvUFR7Fs0qxonqfilKKGehkJR1eSbPU1ZmDOcw5sjCHnZ8GUv8+rwoF4TABJnlvAaZ73YKdkmS3IQ+XQI98sv0rKbyLAM0s/ErBeI2WAx0FE9p19uyB5G8GRokFZt96zIqmHNUpCXbWeHmAIVcvDk2s6StHqywS5kEATLkHxLRaPQY2axVeluL/OGeHRyevDW/mYdwJgNa7Nlawgnq5PsyyLAdY310gYtwyx8HAMrhkEGOH1udno2sqmZ4vDpUjeSS1NPZ+4gq2/+Nk8KDlLj96IQHYnhV8PspcSG0Q9WCBWbVQ12r4K2+8XIO9gI8hg5/7kSevNz8Vcamcy84ezJpHZ88m+LpNLDmVL2BiMN6qMhMf+Ka3KeRyUgkDo9nZf9s/JjehkjGiKZJs74YnNzgPnKfeu53l2xyQw/QxG9kB0dOAGsiRFz/VZhuSyWK3cc60lvaMuDFjzSdMCuqAHzZrc0iVD412FZAtgE8Ek8Vi7XXhokwnXOT6Y3rSA5lpJhUPgI56Xfl5lXxD3opFN2shTaCe95KEsjcoag="
+
+[[package]]
 name = "lz4"
 version = "1:1.9.4-3"
 system = "archlinux"
 url = "https://archive.archlinux.org/packages/l/lz4/lz4-1:1.9.4-3-x86_64.pkg.tar.zst"
 sha256 = "aa92898d7ed44ce1929c1d59bd07c45afcaa7226fedb1772e0fd7672de499222"
 signature = "iHUEABYKAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCZfdwFAAKCRBtQr3RFuAGjxHcAQCUFpgmktTvH5FRfhqmUjciCqHPOPPw10/CD/X9aYEKxwEA4raaSN3gOj/ISaJmHb9NIwih+pxw132G5f7g+9F/mQU="
-
-[[package]]
-name = "make"
-version = "4.4.1-2"
-system = "archlinux"
-url = "https://archive.archlinux.org/packages/m/make/make-4.4.1-2-x86_64.pkg.tar.zst"
-sha256 = "7c1bc0d882f7c8d1bcb305eb7efaabc19ed6afa5a9a443575fa0d5ed57985535"
-signature = "iHUEABYKAB0WIQSZH24/B2XPYpWIhYYTmwnaW/DTOAUCZBT0lQAKCRATmwnaW/DTOKwJAP9/kfT3rO0NhbD8wuI6ajzjyKtrl4SfuU0yu/PKByXQOgD/aYSvsyXylJhCadU2smO4LbP2Vj9fnIvEwPvbXbesVQ0="
 
 [[package]]
 name = "mpfr"
@@ -643,11 +659,19 @@ signature = "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCZjqbXF8UgAAAAAAuAChpc3N
 
 [[package]]
 name = "musl"
-version = "1.2.5-1"
+version = "1.2.5-2"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/m/musl/musl-1.2.5-1-x86_64.pkg.tar.zst"
-sha256 = "914fc5796209750652303e830c6ddc2478ffa27261801592ac49f64a1456bac6"
-signature = "iQJLBAABCAA1FiEEiee5MxxK59f699MFwTIpOVS75K0FAmXjEw8XHHNwdXB5a2luQGFyY2hsaW51eC5vcmcACgkQwTIpOVS75K1yCg/+KLpAazqnCdR0qY6xNJM/v21L8B5Jl6+KIQCZ9NCTn0/33gQBCvMGghcx1WblzEslI6zjq2xHVzO7o2X2c3Vkl/XgsomY/DeXzK/GGVm+4yeyVe/M5CALqnzkHZiqEQvNkUW+7IKMHxmVWeXDhSWEv0k2SwEkl8K+Ge+BK1wdhXoj767YZXuf+09o8e6a4T1tLjauopBE7/7fXYD7/G0/UJueVQrFv72ouujL+Cazpv7vZfJYT8WjmhgPfHxBGKKNYzb9VICSw1jw6O1KAOd6b9j6kA+LkBYMkzFzCrVB3T5QXFSntUv2lBFvX03/E+1uTv3aAoBDFvaE1nveXODl35Tvh8/hyUdiKYjpbAY4nlrgjjgZF7ydL6cmv0KkhGNa6sVLANScKBRGjeGoHVWEIRLIeFG7KUymUPE6Yndak7Y6INr1lDH7gEqiWcVEd+27GstCk4g+dijrIV3PNer3JzJzBNYVxRXaIeIpSgn61tsca0KrmS3kr4j6fwX3K4ILBL4HcCsSCnk2HUFDtBlMiYGACsB/ue10MVmDZF1LDs8jxyrYLviCgR7e6iENAmkbd0UhQniC0vG2HiAJA2K6IYk9btw4ItUtFUdm7OnIcJlIt6LCaa9V3IJ87uZIPNlWCGZxPLPMyByCAGSOOvmYO5U248Sknqs4FFDGKVsrHAo="
+url = "https://archive.archlinux.org/packages/m/musl/musl-1.2.5-2-x86_64.pkg.tar.zst"
+sha256 = "146b60543069d4eb92fd9086ffd6f442ee0a1f41f724445adc29af80693ce2da"
+signature = "iQJLBAABCAA1FiEEiee5MxxK59f699MFwTIpOVS75K0FAmaUdzsXHHNwdXB5a2luQGFyY2hsaW51eC5vcmcACgkQwTIpOVS75K2C+g//ddIjb7CKai01nuuzLd9hZQBP51iBe+lYdhv5lxlKaSzQZXHVUGXDAZdb7TaV9pbzdGPE+l5V2ZngivXdR5twUDWOQzvorXdxLgX7trBTghLDTBIKu6jPtrH2bNWrL8A908RumQVeWsOxUcompgAsRpQ4DhZkzk8325k9et0Nv1oQic96B5G1WefE85IYc2PDJeRhfyfnZmQ15aoVhohyhF0XSudlJSc/hqMZePW8tmyYz4ltvgOs4EF3smNwOaZVOew+w/5vOCYaSre5MFwHiilvYJaWhCji10m0MrBzLhRx0ZfRlBwTGbsToRbmczuwMXoYIiJsI2OiXsZD5/X9T5yPjl7pWP7uLaNTXCcbfrCZIWMVBXYQFxnWhUbKFZu8E7eXU2z75GukkC7GjR+VKw+SFH06Xdq73JltIXURRKe03uigC8ciME1xHOMv5kc1pQukQC/hTaR4GPF32pOX27CPQkNQ0dhRi1Cgyt47V+3GncI+mhlY3gJsCv31+Z0kM+WornVJYFSQnO0/frFPJaZUt0ONO7lHU2UMTe2tHm+zFHuHh6xOGaMjdRslrzq0Pby0xMb6nT0HsT1VXfSW30rywN1UPLd3TxAXGkG3SS8szftrLrmK6NAsK5tWfd5H2tiwSibYNnYYYVB720LKBl7bgpGFicdROohXJKqXsvA="
+
+[[package]]
+name = "musl-aarch64"
+version = "1.2.5-2"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/m/musl-aarch64/musl-aarch64-1.2.5-2-x86_64.pkg.tar.zst"
+sha256 = "a127125a8b889341e8ee1d9a68b75b7afbc7af9a13e0203c460b5bf266084df3"
+signature = "iQJLBAABCAA1FiEEiee5MxxK59f699MFwTIpOVS75K0FAmaUdzwXHHNwdXB5a2luQGFyY2hsaW51eC5vcmcACgkQwTIpOVS75K3i7xAAgtV4szRrzrfudev6aAAIeGUMMmYRuzSjicbS8+2jMdJUTeWkHRpEWkA/f+T29ki9OlJAHzotThWREgetwkoXrovUfugb0MNY++u4Oo3N2Z72AS1ndweWy/0ewz/0sOuVn6NNfTek8BhXa9lzhPLbd+JLRHXqlt4gz6tS8ax9aiXuUqKIqjo00HTfwiMYyaUbRx83eJL/0549A2Rq72Ju7vDIBnRe2Bf5brYkRBluVbOKgEEEDJ63pwzzw2K694YJyIzGmeLf5ZKG2dVyQZ9RoR08bwMXGKt7qInijgbDozNp3GOdvVL/v4wMByc1TjqazycJmSgKqFALgLxBsxm9LjT+j2OCpz5imS4I1OecuJSO5bTHZNhkgE9rqsGdjVNUjLSgvQem/k8OdIWrnF5W7bfCZEI7EUI5qxAG3uh6jCG/LEJkjIuR7IN17sDtl50DcPpN/Sr4wcETXfoz1NNB3b8ZwBITkADBnDu+lmG2+x7pPXicZSVOPN8i1IYnq8r11Aw1GxOCXQZsGfsJgByjWYs5iD1Y/8JLlsw7aagwjZoh2bMGadlA+tzY83+2OP2Nq4Vrhwum96ec7vUoe3kKADJ0751IHW3+anqglMivyOXmngBObAcoWb/Q1HrTMTQy6SGemdM614Yw/h+tJizeOvugkqbX3gny7grDrIgmjRY="
 
 [[package]]
 name = "ncurses"
@@ -680,6 +704,14 @@ system = "archlinux"
 url = "https://archive.archlinux.org/packages/o/openssl/openssl-3.3.1-1-x86_64.pkg.tar.zst"
 sha256 = "3d0540fb0d4196c9d8bc369c7d2faa8800a37d4f57e4b3cb418dd438fd3c59dc"
 signature = "iHUEABYKAB0WIQQ+gMoai4n2nLpX2Yp2pe+QVESaXAUCZl9thAAKCRB2pe+QVESaXPZ8AQDIUORLQtyVcPznVihzQAv8blUov4Hed21VTKr3xyrI2AD/Vsb6QEV/ITwbEk9hKgi4rjruYyMaDUSliBd9XQL7PgA="
+
+[[package]]
+name = "p11-kit"
+version = "0.25.5-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/p/p11-kit/p11-kit-0.25.5-1-x86_64.pkg.tar.zst"
+sha256 = "fddfcb0eede8619d1185f9834426c27db68407fa5fb2eabd4cba360116fa536b"
+signature = "iHUEABYKAB0WIQSDvIiJNRtd67toQW64rAhgDxCM3wUCZob0hwAKCRC4rAhgDxCM3/AIAQDWuPLCUdBREcAK7E0Yjz7ZhXdoF1yd4u4PcMuswFhNYQD9GmxAlIR6t0FGFkqGzr3nzImV0pb0v5t8Sb0OPLrBsQc="
 
 [[package]]
 name = "pacman"
@@ -816,14 +848,6 @@ system = "archlinux"
 url = "https://archive.archlinux.org/packages/u/util-linux-libs/util-linux-libs-2.40.2-1-x86_64.pkg.tar.zst"
 sha256 = "f2b27ad8987bd146aa9431aec36cbd73b0a820c4996b91cac15afcebd96ea399"
 signature = "iHUEABYKAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCZoZctQAKCRBtQr3RFuAGj94rAP0ZLhpNPjBwnpon0hlXT6gKrRAxiD5BdsDCPjSTA5B2rgEAhjBvxUGHDD2X9meZ0uE8ilKpjjmyQtBWHASwab5VBwo="
-
-[[package]]
-name = "wget"
-version = "1.24.5-3"
-system = "archlinux"
-url = "https://archive.archlinux.org/packages/w/wget/wget-1.24.5-3-x86_64.pkg.tar.zst"
-sha256 = "fd928001f09cf506f5db8614501d49abea2c18e6546140db9bac450cf0e60b80"
-signature = "iHUEABYKAB0WIQRUwf0nM2HqUUojd5Pylr3lA2jGzgUCZnw1DgAKCRDylr3lA2jGzsANAP4zcY+oGqNvPyR4AVVGPESLblBvPrvq2PuUAh5edlgPRAD9EaxkTGK1BxQh5ssBmf3+fvYDnbJjEhy1ZCBWbtriGwU="
 
 [[package]]
 name = "xz"

--- a/pkgs/sniffglue/repro-env.toml
+++ b/pkgs/sniffglue/repro-env.toml
@@ -7,8 +7,7 @@ dependencies = [
     "aarch64-linux-gnu-gcc",
     "cargo-deb",
     "gcc",
-    "make",
     "musl",
+    "musl-aarch64",
     "rustup",
-    "wget",
 ]

--- a/pkgs/spytrap-adb/build.toml
+++ b/pkgs/spytrap-adb/build.toml
@@ -19,23 +19,6 @@ set -e
 # 2024-01-01
 export SOURCE_DATE_EPOCH=1704067200
 
-wget https://www.musl-libc.org/releases/musl-1.2.5.tar.gz
-echo 'a9a118bbe84d8764da0ea0d28b3ab3fae8477fc7e4085d90102b8596fc7c75e4  musl-1.2.5.tar.gz' | sha256sum -c -
-tar xf musl-1.2.5.tar.gz
-
-# Arch Linux currently doesn't have cross-compiled musl libc, so we build our own
-pushd musl-1.2.5/
-CROSS_COMPILE="aarch64-linux-gnu-" \
-./configure --prefix=/usr/aarch64-linux-musl/lib/musl \
-  --exec-prefix=/usr/aarch64-linux-musl \
-  --enable-wrapper=all \
-  --target="aarch64-linux-musl" \
-  CFLAGS="-ffat-lto-objects"
-make
-make DESTDIR="/" install
-mv -v /lib/ld-musl-aarch64.so* /usr/aarch64-linux-musl/lib/
-popd
-
 # configure the right linker for cross compile
 mkdir -vp ~/.cargo
 printf '[target.aarch64-unknown-linux-musl]\\nlinker = "/usr/aarch64-linux-musl/bin/musl-gcc"\\n' > ~/.cargo/config.toml

--- a/pkgs/spytrap-adb/repro-env.lock
+++ b/pkgs/spytrap-adb/repro-env.lock
@@ -43,11 +43,11 @@ signature = "iHUEABYKAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCZbDRHwAKCRBtQr3RFuAGj1S
 
 [[package]]
 name = "archlinux-keyring"
-version = "20240609-1"
+version = "20240709-1"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/a/archlinux-keyring/archlinux-keyring-20240609-1-any.pkg.tar.zst"
-sha256 = "1498cbf8f9511a7c4f52b40b392bf8779e9543195f2a0a95a9dcda7b49dd0f9f"
-signature = "iHUEABYKAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCZmYV4QAKCRBtQr3RFuAGj5TKAQC4YJtPS54Mbb1HpkGBtt/rnHcZJwCTGkZ5oyPcWqen+QD+ICYfcLg4P1+sj+hMfPmDXQf4aKBLDrFkKKvSvCgy6wY="
+url = "https://archive.archlinux.org/packages/a/archlinux-keyring/archlinux-keyring-20240709-1-any.pkg.tar.zst"
+sha256 = "a6f573fc97fc21b55504a4d75d010257792847a5b87f19edff4ffb662f6f53a2"
+signature = "iHUEABYKAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCZo2s1wAKCRBtQr3RFuAGj9MSAQDCI730nuxWZ70VM9xGZZZDyLwb6LdAN+fbUdkNzaE3wAEAsNqHKFnUKRnBXwGOv3j8VrP+XaGD0P2QJAEocEeWiQM="
 
 [[package]]
 name = "attr"
@@ -226,14 +226,6 @@ sha256 = "f7d9994d70d5bac0e99a66508673abba271d1b0b0598e001b7a677d182663500"
 signature = "iQEzBAABCAAdFiEEW34/txt/EDKaHAOrdx32Yn7faB8FAmZbgL0ACgkQdx32Yn7faB8F/ggAt6EqPhQ7KsinXsEEJhE+ammbeflgv4eKpmhP6wlfnb0Cg3TerAKdEbXUdR3rpcztE2f/zLJ+Fs9dYV5DOqcMV5cpLWD0NYjo/SmiZMVjM1/ZWskbnhyMAsfDQwUXXZYruMiOGdMpJFu8sqKBkQqrd4cOkn3AF2r2wXW+PF2r2yb0K9mv6YW285RIEo7aphVsI0LZgKbrksDeMbWQF3U3A1WHrVX1rDXPB0CSnxkIaEm3erzaFj8dhrFd4/7k7iIUjLFP2Ev6HhBjr0CA7V62LtJ9EOyGtYCY7SB4SKL8EWdWJK513jpVe6gu/5M5A3H0zmA8w5E83zW/Z5nbZvnFkQ=="
 
 [[package]]
-name = "gc"
-version = "8.2.6-1"
-system = "archlinux"
-url = "https://archive.archlinux.org/packages/g/gc/gc-8.2.6-1-x86_64.pkg.tar.zst"
-sha256 = "6210a1e7e00d3162f175f9ab318a3da928495210b1ea411dcb66bf5e1f382daf"
-signature = "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCZb9oiF8UgAAAAAAuAChpc3N1ZXItZnByQG5vdGF0aW9ucy5vcGVucGdwLmZpZnRoaG9yc2VtYW4ubmV0MDVDNzc3NUE5RThCOTc3NDA3RkUwOEU2OUQ0QzVBQTE1NDI2REEwQQAKCRCdTFqhVCbaCmQdAP0fleaFihboUqrAdlMxvO5OUJiXXxLtimhQj2e3rD9L3gEA0YzMCzi4GS6GlV1pa/hZ68bPL2gYz2goni9/aLXhMwY="
-
-[[package]]
 name = "gcc"
 version = "14.1.1+r58+gfc9fb69ad62-1"
 system = "archlinux"
@@ -250,6 +242,14 @@ sha256 = "7605cb1ab1830dbdd564591d33adeec78ce79c1733bd98f36ba3e81eb9748b78"
 signature = "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCZk3zsF8UgAAAAAAuAChpc3N1ZXItZnByQG5vdGF0aW9ucy5vcGVucGdwLmZpZnRoaG9yc2VtYW4ubmV0MDVDNzc3NUE5RThCOTc3NDA3RkUwOEU2OUQ0QzVBQTE1NDI2REEwQQAKCRCdTFqhVCbaCugeAQDgJyrXuoZnSZFU/gz5rGccNOuGSgOvfYX2YTY1drfb/AEA4pmZIr4MJC/1XQF5AmrhxTX491TtbJgxdstI+1KysAs="
 
 [[package]]
+name = "gdbm"
+version = "1.24-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/g/gdbm/gdbm-1.24-1-x86_64.pkg.tar.zst"
+sha256 = "2712f2747f887ff19ad4151143e506e80254a0a0db0e8b968adb6634da7800ab"
+signature = "iHUEABYKAB0WIQRizHP4hOUpV7L92IObeih9mi7GCAUCZoa2fgAKCRCbeih9mi7GCKXhAQDIaNqIfZ2hIa29L7FE1axM7Ui45KQxU/XOCC2cnzisvAD/aecNLEqMxSnE/FsOhZdi0dAHLAuOjVRSpF6IbtF1NgM="
+
+[[package]]
 name = "gettext"
 version = "0.22.5-1"
 system = "archlinux"
@@ -259,11 +259,11 @@ signature = "iQEzBAABCAAdFiEEW34/txt/EDKaHAOrdx32Yn7faB8FAmY7WIYACgkQdx32Yn7faB9
 
 [[package]]
 name = "glib2"
-version = "2.80.3-2"
+version = "2.80.4-1"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/g/glib2/glib2-2.80.3-2-x86_64.pkg.tar.zst"
-sha256 = "5097ae4a68ce205c4ffa370d5d9ba3e4ad9afb97d61e3d3f61d9b944813e7ad4"
-signature = "iHUEABYKAB0WIQSDvIiJNRtd67toQW64rAhgDxCM3wUCZmjHogAKCRC4rAhgDxCM30ONAQDMZoZSkJDOZDPD9PMLvhbK1VJxJp8VRgdxG1OILR9kfAD/evaIoFqw0LCQaTkKdSavJURgzmjh9g+LJ4FM7OnIzwA="
+url = "https://archive.archlinux.org/packages/g/glib2/glib2-2.80.4-1-x86_64.pkg.tar.zst"
+sha256 = "047121788777ae88726ee10525fba0ab05cc495cdb336a45bea6cdd0793c8d06"
+signature = "iHUEABYKAB0WIQSDvIiJNRtd67toQW64rAhgDxCM3wUCZoxhigAKCRC4rAhgDxCM37jmAQCMi355gHS4atKFg2Zr5R5hElvjlTp2vx7s2MniqS4usAD+KrBXRueBCElmnuplANh2d71qDwjAG7FFueZk8bp61wA="
 
 [[package]]
 name = "glibc"
@@ -304,14 +304,6 @@ system = "archlinux"
 url = "https://archive.archlinux.org/packages/g/gpgme/gpgme-1.23.2-4-x86_64.pkg.tar.zst"
 sha256 = "e2a1b35695ea4d88fc19e74bc554b7f45f0731e7028e066e4100354586728973"
 signature = "iHUEABYKAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCZiYi2AAKCRBtQr3RFuAGj2U+AQDvXt3MzYy4Fm+Nu1lul/pTYW3pIdGh7SZ2pvkMHNhUXgEA8moKzHQLFtW6g51MSFbUz2pMunFR1Bbv7DzNzgV7GgI="
-
-[[package]]
-name = "guile"
-version = "3.0.10-1"
-system = "archlinux"
-url = "https://archive.archlinux.org/packages/g/guile/guile-3.0.10-1-x86_64.pkg.tar.zst"
-sha256 = "bf4d1b474045a88c7ad97b1ce56e8dd5786e5a10de02a8d33dc8f041edc8d01d"
-signature = "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCZnkshF8UgAAAAAAuAChpc3N1ZXItZnByQG5vdGF0aW9ucy5vcGVucGdwLmZpZnRoaG9yc2VtYW4ubmV0MDVDNzc3NUE5RThCOTc3NDA3RkUwOEU2OUQ0QzVBQTE1NDI2REEwQQAKCRCdTFqhVCbaCruHAQDnjJsHGhq4cae34rHS1z+Hr6yzjVQSxvA6SE9XpredlAD/cstobLSMUsHswxf5df94XkoDPJdJs44uXE/iu9gsgQg="
 
 [[package]]
 name = "hwdata"
@@ -386,6 +378,14 @@ sha256 = "9abd6fd54052b48b2bac6e709e25e7be876f68d84949ed4615a3fb8803f2a736"
 signature = "iHUEABYKAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCZegwsQAKCRBtQr3RFuAGj3QXAQDqrsXu36gY3rprKLSh3b3O0VYDQk7UHHSCAveZEHpvxQD/dR6SLukPahSQ8LABJmCFHk4w4d1PgBDRCczcaMYR2QE="
 
 [[package]]
+name = "krb5"
+version = "1.21.3-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/k/krb5/krb5-1.21.3-1-x86_64.pkg.tar.zst"
+sha256 = "7ce8f30ccef0650b964defb7a539c72d5e40fcd288f5f397c1b824d3f4431b2b"
+signature = "iQIzBAABCgAdFiEE4kC1fixGMLp2ji8m/BtUfI2BcsgFAmaJc6UACgkQ/BtUfI2BcsjO0w//R4djAXEL1QcOF/Jh4Ukqy+k+AhvnNSJN5JPhOkvJKc7DqCudBaFcuHdGno6KIAyg42q9PjeIBWxH2kcIVojmGZ+zPvscdX0mjwJAxZ+tBDfa54eOqtnUMGbPDL5QoGeZjfhdQ0hHOFDkpioz8c1hVjdTRvqkC6J5uUGH2SQmD9HfBUFv5O9g/QW+JJI4kXFYnewZewrDOFAccYFjcBjioY1L898+2freJ2JOIh5acf1mtQol/cZhOQevQ/SdZ+BsYZOLp3QFU+IE4Wg+3h2ayEa88A7i/U6ln03GkYNySY1UmqKwrALE9ixW8BSKXoVldtjyiLFH1PHsr0QLmn1IBEt0bis5L059JEdaCv8JKeEElQORUQNLXS6fBV/Oo4oc6mI0SiyOvMPchwkrgvSkh2UKz4AGtpan5EvwRDdaNdhZiCVEDWLIZ6sm0sXRIoJzrB4SsCux9eZnma6Yls47PjgR75ZFbNCr/CHHpZMHyL7mjb8fpZl12mXRcRAMo+3laZsJxUUOymtf3gb/SKQ5rDlYfHxtFaoRvUzKOscUT1d5PQ90KAuD0rbRmUynxBd4FqLAPs7xpcFJtboAsLd1Iax04gAxNtmQQ9F2SujJD+h/LoPwtqu2rU07e9+rcXtKqwYqTxH8TDGpEERsxkUcaLkvsz3sOxIEAUzubYnBn4I="
+
+[[package]]
 name = "libarchive"
 version = "3.7.4-1"
 system = "archlinux"
@@ -403,11 +403,11 @@ signature = "iHUEABYKAB0WIQRizHP4hOUpV7L92IObeih9mi7GCAUCZgqJbQAKCRCbeih9mi7GCNv
 
 [[package]]
 name = "libbpf"
-version = "1.4.2-1"
+version = "1.4.3-1"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/l/libbpf/libbpf-1.4.2-1-x86_64.pkg.tar.zst"
-sha256 = "70e86fd8bf8e6a0850eed15a580376049d988a28e987afa4c311abd2b1af611c"
-signature = "iQIzBAABCgAdFiEE4kC1fixGMLp2ji8m/BtUfI2BcsgFAmZSc7YACgkQ/BtUfI2Bcsg/HBAAu1v9RTktILD/N34CyIuLCDci6qPeEC3oXDIpZLBnXTwcIwo2Hhhn5n3Sz+k/Tbb6gRMIRhsnqwpxANRo38B9QMODyfeM4wKDNusV1cYUtE/9X3g00dHOYwDu//a/eLj7vHnUWTnFT3zebtRqFUtsFCKr1gogppkQzKCuYx7Nhrl/Z/1md7LEQZXxKWt9d4VSjex4noNMu+7ZujWKZFfYjyPyBzX2mDe96VEBT8BGnMzMjHT07Z7094BAHmVBrNmaJYxkNn34zhMAnG03Lxq93RHgnRJ3K7yzx+rRuEwsqg+7w/47nvgq6K0EaB04jQ6HbW/uIAn3sWIYgMZFIeBxeiCn5qQsNH0u7kSy3fivVuKADmVNG7UphHa3CVcSUi+9nSgt7Ug1RM3vsfX6c/+OiJnQoDHl/ITNZTsmMjc+H0jcJf+3zHyLnKObgEDOTehixOHWUnA8I0MgGCWDeXD8AwSyFl1kponCDgFbrVBwWgv5YvS0lvgTnRo65ix2g/XhVCeqLmgb42t5lnA+QSoRmY21CGalMF1JNvzMwhRr0ZTslbr/OUphjumFylhRcH89QX5HD1UZcq/tbECWsenQiVycN/4iKA0tebCQVyfiqC9yf0A0cKgl4G2gyAO1nN0iZ/5k8zBglcmAksi8xzfeLpGCs36wYnC9Z+HzvEV6StA="
+url = "https://archive.archlinux.org/packages/l/libbpf/libbpf-1.4.3-1-x86_64.pkg.tar.zst"
+sha256 = "5c265558f023b70a5bf91a18a8ef91ef997b76937aff1e02899e8a564ba9df43"
+signature = "iQIzBAABCgAdFiEE4kC1fixGMLp2ji8m/BtUfI2BcsgFAmZgmLQACgkQ/BtUfI2BcsiYVw/6A4E4pNMMnrAQpVElsIoe5mgGjKFiZSQiveupLzqETBHfR3tEo+4pSd/K5COOg0OcZbnVf0QQhWgAlHZwszQdbiqTO6QRRvs8D19g2cDB1id0QjetR5Psxiblv97nOwsD0VSERBZ7DIeD+ssZJs+q31P9fF9jlzXYWV6tlBvSCNRc3vS7ShpO/oFm4SriKbJb5/luIPA4vY/JkPN/LUn5kEc/mqynt8yX/xTA1cnF23YNQ9lc2J8ZMYi30guLbFlRjeXgjaPYYxjYZ6A8j3ua/06VFEhjgCno6WUqBt2qKwZzcra57SKoUh7COah18rHQN+4IxGAW6LUPTvaghWiMFA2Be/R1itx72S4AlXym9/7KLs1mrG4YEeCbq5XYfhCec3oie0dfyKmOT61QhrymLlu7EwkDG1neqk+xo595up7m18q3tdiCPRx+AQZd9cxM1+wgjje2ZNSLRrP076AEZenLYADxhhnL5Omr70d7mGZooMjMu7J4AWxfWXmFYZYxhaZ9ywbWnfJJhkdFPuczOZU38Am0lCZpRSSPt3IYxTxzpQt3esSzhXIOTzH67P4ef55TeIqojzhdXcX8mr1J0LJGduG91lfMTb7X2tiEq8XAGmYHEpMt4VnfdG+wyMLCQXzHWAu1CzDcxBNft79rJE9xaKC/9550FsBkERN501Q="
 
 [[package]]
 name = "libcap"
@@ -499,11 +499,11 @@ signature = "iHUEABYKAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCZfdwygAKCRBtQr3RFuAGj3a
 
 [[package]]
 name = "libmpc"
-version = "1.3.1-1"
+version = "1.3.1-2"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/l/libmpc/libmpc-1.3.1-1-x86_64.pkg.tar.zst"
-sha256 = "a83324a476cae86887aa3e3811b2e72c31471a81be0254e379c244e2df531c1b"
-signature = "iQEzBAABCAAdFiEEFRnVq6Zb9vwrc8dWek52CV2KUuQFAmOfE/EACgkQek52CV2KUuRNEwf6AkQRJ6MKo3+8qZ5DoL1AUfEbRy332+0DbmhqVAZAVR6SDYwr8yTYc5L9zWtRYA++Nh0zah4P6o3XXJISOfLLpQHGPI1jZ/1IGTJlCt0yo+KU891YfQQO95TCAa77oT9Njkxr6imF0vP5kR3PA5sEvqD0iCu69s0TQu2uzsVqigNmbWU3LVv47BrF1T+C31Oa6cRWmjDUtn2ls/jYn+BPvuCO9TyH/3d2lQ1CCM+H1cCDcxzBSmaYSVQUbM6x8YAdFKDZKEbwuiCGTwKIV5ZRar4UiiBdeuJzF0vSy51VdcZpvf30HU8VuJ2Q+mv5OfyHjt/HBCkEyn1b+XufIqb0Xg=="
+url = "https://archive.archlinux.org/packages/l/libmpc/libmpc-1.3.1-2-x86_64.pkg.tar.zst"
+sha256 = "10554706eb15ed2186fbd55fd5db8fa5919788ac9a75d26c0b9ef5bdfca9d470"
+signature = "iQEzBAABCAAdFiEEFRnVq6Zb9vwrc8dWek52CV2KUuQFAmaHCZwACgkQek52CV2KUuRjbAf/TmL9cCMXYTGsNmR2om6kT7XjczfZoFR9AM0FSTUNy5AuNZNUUCfm6ie6F4rFwHc3nETOSojScOZauZlcNiLrVriHYYFSZ8EhKiCJCo68a7KTbceBNoBuT6AEIpGMpIMti/cvWhu8VXl5JIRo8LNPBzDih05aCDUJ2nayKPYNHalDayu87sDXzJYXuzC8KD7XmUa7Kirn0ZpA4VZXc8CUjYYvn0wvRwLKQP4WMpszxmblQWjMVbQxh7dwC+gPtqIANVjoGKMRfr6QpT03XXIEaTBKbMsxeYFvwn+y2JN30t6oFI6LJADZ22VwimEzu06u+x9c+3+pr4k7Py43OCOGmg=="
 
 [[package]]
 name = "libnetfilter_conntrack"
@@ -642,20 +642,20 @@ sha256 = "90a7b061db393d9a6f68244f8772053f42d6cce586c561200d2586d4d662e504"
 signature = "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCZjoV/l8UgAAAAAAuAChpc3N1ZXItZnByQG5vdGF0aW9ucy5vcGVucGdwLmZpZnRoaG9yc2VtYW4ubmV0MDVDNzc3NUE5RThCOTc3NDA3RkUwOEU2OUQ0QzVBQTE1NDI2REEwQQAKCRCdTFqhVCbaCkbGAQDgE3AKw3Q01iehBZZsnkeeJItviKl5ymy9TKMrSeReXAD/QkZ9wK4v8R09cvnQPHfwnWV8Myhey1EIiDXnaKhp5Qw="
 
 [[package]]
+name = "lmdb"
+version = "0.9.32-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/l/lmdb/lmdb-0.9.32-1-x86_64.pkg.tar.zst"
+sha256 = "474c654b589b25f80b6bed806b6f5b79ff88f2052d9a54848299ef75a23e3dd5"
+signature = "iQIzBAABCAAdFiEEtZcfLFwQqaCMYAMPeGxj8zDXy5IFAmXLraQACgkQeGxj8zDXy5KzBQ//ainnkpc4j/YWOqY5bYu8BcIIrjk8dgEu4zV3w3QVQflJ160/x1vZPdcCsI5Ur3v9+dQvBYWgNfkSIrMNay+JeAkYpQ9a1MCaOlXoSmHmLUiyzVh9zNy5bY8yDDPNFUJf2oEyAKHvUFR7Fs0qxonqfilKKGehkJR1eSbPU1ZmDOcw5sjCHnZ8GUv8+rwoF4TABJnlvAaZ73YKdkmS3IQ+XQI98sv0rKbyLAM0s/ErBeI2WAx0FE9p19uyB5G8GRokFZt96zIqmHNUpCXbWeHmAIVcvDk2s6StHqywS5kEATLkHxLRaPQY2axVeluL/OGeHRyevDW/mYdwJgNa7Nlawgnq5PsyyLAdY310gYtwyx8HAMrhkEGOH1udno2sqmZ4vDpUjeSS1NPZ+4gq2/+Nk8KDlLj96IQHYnhV8PspcSG0Q9WCBWbVQ12r4K2+8XIO9gI8hg5/7kSevNz8Vcamcy84ezJpHZ88m+LpNLDmVL2BiMN6qMhMf+Ka3KeRyUgkDo9nZf9s/JjehkjGiKZJs74YnNzgPnKfeu53l2xyQw/QxG9kB0dOAGsiRFz/VZhuSyWK3cc60lvaMuDFjzSdMCuqAHzZrc0iVD412FZAtgE8Ek8Vi7XXhokwnXOT6Y3rSA5lpJhUPgI56Xfl5lXxD3opFN2shTaCe95KEsjcoag="
+
+[[package]]
 name = "lz4"
 version = "1:1.9.4-3"
 system = "archlinux"
 url = "https://archive.archlinux.org/packages/l/lz4/lz4-1:1.9.4-3-x86_64.pkg.tar.zst"
 sha256 = "aa92898d7ed44ce1929c1d59bd07c45afcaa7226fedb1772e0fd7672de499222"
 signature = "iHUEABYKAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCZfdwFAAKCRBtQr3RFuAGjxHcAQCUFpgmktTvH5FRfhqmUjciCqHPOPPw10/CD/X9aYEKxwEA4raaSN3gOj/ISaJmHb9NIwih+pxw132G5f7g+9F/mQU="
-
-[[package]]
-name = "make"
-version = "4.4.1-2"
-system = "archlinux"
-url = "https://archive.archlinux.org/packages/m/make/make-4.4.1-2-x86_64.pkg.tar.zst"
-sha256 = "7c1bc0d882f7c8d1bcb305eb7efaabc19ed6afa5a9a443575fa0d5ed57985535"
-signature = "iHUEABYKAB0WIQSZH24/B2XPYpWIhYYTmwnaW/DTOAUCZBT0lQAKCRATmwnaW/DTOKwJAP9/kfT3rO0NhbD8wuI6ajzjyKtrl4SfuU0yu/PKByXQOgD/aYSvsyXylJhCadU2smO4LbP2Vj9fnIvEwPvbXbesVQ0="
 
 [[package]]
 name = "mpfr"
@@ -667,11 +667,19 @@ signature = "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCZjqbXF8UgAAAAAAuAChpc3N
 
 [[package]]
 name = "musl"
-version = "1.2.5-1"
+version = "1.2.5-2"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/m/musl/musl-1.2.5-1-x86_64.pkg.tar.zst"
-sha256 = "914fc5796209750652303e830c6ddc2478ffa27261801592ac49f64a1456bac6"
-signature = "iQJLBAABCAA1FiEEiee5MxxK59f699MFwTIpOVS75K0FAmXjEw8XHHNwdXB5a2luQGFyY2hsaW51eC5vcmcACgkQwTIpOVS75K1yCg/+KLpAazqnCdR0qY6xNJM/v21L8B5Jl6+KIQCZ9NCTn0/33gQBCvMGghcx1WblzEslI6zjq2xHVzO7o2X2c3Vkl/XgsomY/DeXzK/GGVm+4yeyVe/M5CALqnzkHZiqEQvNkUW+7IKMHxmVWeXDhSWEv0k2SwEkl8K+Ge+BK1wdhXoj767YZXuf+09o8e6a4T1tLjauopBE7/7fXYD7/G0/UJueVQrFv72ouujL+Cazpv7vZfJYT8WjmhgPfHxBGKKNYzb9VICSw1jw6O1KAOd6b9j6kA+LkBYMkzFzCrVB3T5QXFSntUv2lBFvX03/E+1uTv3aAoBDFvaE1nveXODl35Tvh8/hyUdiKYjpbAY4nlrgjjgZF7ydL6cmv0KkhGNa6sVLANScKBRGjeGoHVWEIRLIeFG7KUymUPE6Yndak7Y6INr1lDH7gEqiWcVEd+27GstCk4g+dijrIV3PNer3JzJzBNYVxRXaIeIpSgn61tsca0KrmS3kr4j6fwX3K4ILBL4HcCsSCnk2HUFDtBlMiYGACsB/ue10MVmDZF1LDs8jxyrYLviCgR7e6iENAmkbd0UhQniC0vG2HiAJA2K6IYk9btw4ItUtFUdm7OnIcJlIt6LCaa9V3IJ87uZIPNlWCGZxPLPMyByCAGSOOvmYO5U248Sknqs4FFDGKVsrHAo="
+url = "https://archive.archlinux.org/packages/m/musl/musl-1.2.5-2-x86_64.pkg.tar.zst"
+sha256 = "146b60543069d4eb92fd9086ffd6f442ee0a1f41f724445adc29af80693ce2da"
+signature = "iQJLBAABCAA1FiEEiee5MxxK59f699MFwTIpOVS75K0FAmaUdzsXHHNwdXB5a2luQGFyY2hsaW51eC5vcmcACgkQwTIpOVS75K2C+g//ddIjb7CKai01nuuzLd9hZQBP51iBe+lYdhv5lxlKaSzQZXHVUGXDAZdb7TaV9pbzdGPE+l5V2ZngivXdR5twUDWOQzvorXdxLgX7trBTghLDTBIKu6jPtrH2bNWrL8A908RumQVeWsOxUcompgAsRpQ4DhZkzk8325k9et0Nv1oQic96B5G1WefE85IYc2PDJeRhfyfnZmQ15aoVhohyhF0XSudlJSc/hqMZePW8tmyYz4ltvgOs4EF3smNwOaZVOew+w/5vOCYaSre5MFwHiilvYJaWhCji10m0MrBzLhRx0ZfRlBwTGbsToRbmczuwMXoYIiJsI2OiXsZD5/X9T5yPjl7pWP7uLaNTXCcbfrCZIWMVBXYQFxnWhUbKFZu8E7eXU2z75GukkC7GjR+VKw+SFH06Xdq73JltIXURRKe03uigC8ciME1xHOMv5kc1pQukQC/hTaR4GPF32pOX27CPQkNQ0dhRi1Cgyt47V+3GncI+mhlY3gJsCv31+Z0kM+WornVJYFSQnO0/frFPJaZUt0ONO7lHU2UMTe2tHm+zFHuHh6xOGaMjdRslrzq0Pby0xMb6nT0HsT1VXfSW30rywN1UPLd3TxAXGkG3SS8szftrLrmK6NAsK5tWfd5H2tiwSibYNnYYYVB720LKBl7bgpGFicdROohXJKqXsvA="
+
+[[package]]
+name = "musl-aarch64"
+version = "1.2.5-2"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/m/musl-aarch64/musl-aarch64-1.2.5-2-x86_64.pkg.tar.zst"
+sha256 = "a127125a8b889341e8ee1d9a68b75b7afbc7af9a13e0203c460b5bf266084df3"
+signature = "iQJLBAABCAA1FiEEiee5MxxK59f699MFwTIpOVS75K0FAmaUdzwXHHNwdXB5a2luQGFyY2hsaW51eC5vcmcACgkQwTIpOVS75K3i7xAAgtV4szRrzrfudev6aAAIeGUMMmYRuzSjicbS8+2jMdJUTeWkHRpEWkA/f+T29ki9OlJAHzotThWREgetwkoXrovUfugb0MNY++u4Oo3N2Z72AS1ndweWy/0ewz/0sOuVn6NNfTek8BhXa9lzhPLbd+JLRHXqlt4gz6tS8ax9aiXuUqKIqjo00HTfwiMYyaUbRx83eJL/0549A2Rq72Ju7vDIBnRe2Bf5brYkRBluVbOKgEEEDJ63pwzzw2K694YJyIzGmeLf5ZKG2dVyQZ9RoR08bwMXGKt7qInijgbDozNp3GOdvVL/v4wMByc1TjqazycJmSgKqFALgLxBsxm9LjT+j2OCpz5imS4I1OecuJSO5bTHZNhkgE9rqsGdjVNUjLSgvQem/k8OdIWrnF5W7bfCZEI7EUI5qxAG3uh6jCG/LEJkjIuR7IN17sDtl50DcPpN/Sr4wcETXfoz1NNB3b8ZwBITkADBnDu+lmG2+x7pPXicZSVOPN8i1IYnq8r11Aw1GxOCXQZsGfsJgByjWYs5iD1Y/8JLlsw7aagwjZoh2bMGadlA+tzY83+2OP2Nq4Vrhwum96ec7vUoe3kKADJ0751IHW3+anqglMivyOXmngBObAcoWb/Q1HrTMTQy6SGemdM614Yw/h+tJizeOvugkqbX3gny7grDrIgmjRY="
 
 [[package]]
 name = "ncurses"
@@ -848,14 +856,6 @@ system = "archlinux"
 url = "https://archive.archlinux.org/packages/u/util-linux-libs/util-linux-libs-2.40.2-1-x86_64.pkg.tar.zst"
 sha256 = "f2b27ad8987bd146aa9431aec36cbd73b0a820c4996b91cac15afcebd96ea399"
 signature = "iHUEABYKAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCZoZctQAKCRBtQr3RFuAGj94rAP0ZLhpNPjBwnpon0hlXT6gKrRAxiD5BdsDCPjSTA5B2rgEAhjBvxUGHDD2X9meZ0uE8ilKpjjmyQtBWHASwab5VBwo="
-
-[[package]]
-name = "wget"
-version = "1.24.5-3"
-system = "archlinux"
-url = "https://archive.archlinux.org/packages/w/wget/wget-1.24.5-3-x86_64.pkg.tar.zst"
-sha256 = "fd928001f09cf506f5db8614501d49abea2c18e6546140db9bac450cf0e60b80"
-signature = "iHUEABYKAB0WIQRUwf0nM2HqUUojd5Pylr3lA2jGzgUCZnw1DgAKCRDylr3lA2jGzsANAP4zcY+oGqNvPyR4AVVGPESLblBvPrvq2PuUAh5edlgPRAD9EaxkTGK1BxQh5ssBmf3+fvYDnbJjEhy1ZCBWbtriGwU="
 
 [[package]]
 name = "xz"

--- a/pkgs/spytrap-adb/repro-env.toml
+++ b/pkgs/spytrap-adb/repro-env.toml
@@ -8,8 +8,7 @@ dependencies = [
     "cargo-auditable",
     "cargo-deb",
     "gcc",
-    "make",
     "musl",
+    "musl-aarch64",
     "rustup",
-    "wget",
 ]


### PR DESCRIPTION
This could be simplified through work of Sergej Pupykin.